### PR TITLE
Refactor tests for network configuration parsing

### DIFF
--- a/lib/g3-yaml/src/value/net/buf.rs
+++ b/lib/g3-yaml/src/value/net/buf.rs
@@ -47,106 +47,73 @@ mod tests {
     use yaml_rust::YamlLoader;
 
     #[test]
-    fn test_single_integer() {
+    fn as_sockaddr_buffer_config_ok() {
         let yaml = Yaml::Integer(1024);
         let config = as_socket_buffer_config(&yaml).unwrap();
         assert_eq!(config.recv_size(), Some(1024));
         assert_eq!(config.send_size(), Some(1024));
-    }
 
-    #[test]
-    fn test_single_string() {
-        let yaml = Yaml::String("2M".to_string());
+        let yaml = yaml_str!("2M");
         let config = as_socket_buffer_config(&yaml).unwrap();
         assert_eq!(config.recv_size(), Some(2_000_000));
         assert_eq!(config.send_size(), Some(2_000_000));
-    }
 
-    #[test]
-    fn test_invalid_single_humanize_usize_value() {
-        let yaml = Yaml::String("invalid".to_string());
-        assert!(as_socket_buffer_config(&yaml).is_err());
-    }
-
-    #[test]
-    fn test_hash_standard_keys() {
-        let s = "
-        recv: 512
-        send: 1024
-        ";
-        let docs = YamlLoader::load_from_str(s).unwrap();
-        let doc = &docs[0];
-
-        let config = as_socket_buffer_config(doc).unwrap();
+        let yaml = yaml_doc!(
+            "
+            recv: 512
+            send: 1024
+            "
+        );
+        let config = as_socket_buffer_config(&yaml).unwrap();
         assert_eq!(config.recv_size(), Some(512));
         assert_eq!(config.send_size(), Some(1024));
-    }
 
-    #[test]
-    fn test_hash_variant_keys() {
-        let s = "
-        receive: 256
-        write: 512
-        ";
-        let docs = YamlLoader::load_from_str(s).unwrap();
-        let doc = &docs[0];
-
-        let config = as_socket_buffer_config(doc).unwrap();
+        let yaml = yaml_doc!(
+            "
+            receive: 256
+            write: 512
+            "
+        );
+        let config = as_socket_buffer_config(&yaml).unwrap();
         assert_eq!(config.recv_size(), Some(256));
         assert_eq!(config.send_size(), Some(512));
-    }
 
-    #[test]
-    fn test_invalid_key() {
-        let s = "
-        invalid_key: 100
-        ";
-        let docs = YamlLoader::load_from_str(s).unwrap();
-        let doc = &docs[0];
-
-        let result = as_socket_buffer_config(doc);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_invalid_type() {
-        let yaml = Yaml::Boolean(true);
-        let result = as_socket_buffer_config(&yaml);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_partial_config() {
-        let s = "read: 2048";
-        let docs = YamlLoader::load_from_str(s).unwrap();
-        let doc = &docs[0];
-
-        let config = as_socket_buffer_config(doc).unwrap();
+        let yaml = yaml_doc!("read: 2048");
+        let config = as_socket_buffer_config(&yaml).unwrap();
         assert_eq!(config.recv_size(), Some(2048));
         assert_eq!(config.send_size(), None);
     }
 
     #[test]
-    fn test_empty_string() {
-        let yaml = Yaml::String("".to_string());
-        let result = as_socket_buffer_config(&yaml);
-        assert!(result.is_err());
-    }
+    fn as_sockaddr_buffer_config_err() {
+        let yaml = yaml_str!("invalid");
+        assert!(as_socket_buffer_config(&yaml).is_err());
 
-    #[test]
-    fn test_invalid_humanize_value() {
+        let yaml = yaml_doc!(
+            "
+            invalid_key: 100
+            "
+        );
+        assert!(as_socket_buffer_config(&yaml).is_err());
+
+        let yaml = Yaml::Boolean(true);
+        assert!(as_socket_buffer_config(&yaml).is_err());
+
+        let yaml = yaml_str!("");
+        assert!(as_socket_buffer_config(&yaml).is_err());
+
         let cases = vec![
             ("read: invalid", "read"),
             ("write: invalid", "write"),
             ("recv: 10XYZ", "recv"),
         ];
-
         for (yaml_str, _key) in cases {
             let docs = YamlLoader::load_from_str(yaml_str).unwrap();
-            let doc = &docs[0];
-
-            let result = as_socket_buffer_config(doc);
-            assert!(result.is_err(), "Case failed: {}", yaml_str);
+            assert!(
+                as_socket_buffer_config(&docs[0]).is_err(),
+                "Case failed: {}",
+                yaml_str
+            );
         }
     }
 }

--- a/lib/g3-yaml/src/value/net/dns.rs
+++ b/lib/g3-yaml/src/value/net/dns.rs
@@ -67,92 +67,80 @@ pub fn as_dns_encryption_protocol_builder(
 #[cfg(feature = "rustls")]
 mod tests {
     use super::*;
-    use std::env::temp_dir;
     use std::fs;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use yaml_rust::YamlLoader;
 
+    // Use a global atomic counter to generate a unique ID for each test run.
+    // This ensures that each test creates a unique directory, even when running in parallel.
+    static TEST_DIR_ID_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+    // A helper struct to create a temporary directory and ensure it's cleaned up
+    // automatically when it goes out of scope, even if the test panics.
+    struct TempDir {
+        path: PathBuf,
+    }
+
+    impl TempDir {
+        fn new(prefix: &str) -> Self {
+            let id = TEST_DIR_ID_COUNTER.fetch_add(1, Ordering::SeqCst);
+            let path =
+                std::env::temp_dir().join(format!("{}_{}_{}", prefix, std::process::id(), id));
+            fs::create_dir_all(&path).expect("Failed to create test directory");
+            TempDir { path }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
     #[test]
-    fn test_as_dns_encryption_protocol_builder() {
+    fn as_dns_encryption_protocol_builder_ok() {
+        let yaml = yaml_str!("tls");
         assert_eq!(
-            as_dns_encryption_protocol(&Yaml::String("tls".to_string())).unwrap(),
+            as_dns_encryption_protocol(&yaml).unwrap(),
             DnsEncryptionProtocol::Tls
         );
+
+        let yaml = yaml_str!("https");
         assert_eq!(
-            as_dns_encryption_protocol(&Yaml::String("https".to_string())).unwrap(),
+            as_dns_encryption_protocol(&yaml).unwrap(),
             DnsEncryptionProtocol::Https
         );
-        assert!(as_dns_encryption_protocol(&Yaml::String("invalid".to_string())).is_err());
-        assert!(as_dns_encryption_protocol(&Yaml::Boolean(true)).is_err());
 
-        let yaml = YamlLoader::load_from_str("example.com").unwrap();
-        let builder = as_dns_encryption_protocol_builder(&yaml[0], None).unwrap();
+        let yaml = yaml_doc!("example.com");
+        let builder = as_dns_encryption_protocol_builder(&yaml, None).unwrap();
         assert_eq!(builder.protocol(), DnsEncryptionProtocol::Tls);
 
-        let yaml = YamlLoader::load_from_str(
+        let yaml = yaml_doc!(
             r#"
-            tls_name: "dns.example.com"
-            protocol: "https"
-        "#,
-        )
-        .unwrap();
-        let builder = as_dns_encryption_protocol_builder(&yaml[0], None).unwrap();
+                tls_name: "dns.example.com"
+                protocol: "https"
+            "#
+        );
+        let builder = as_dns_encryption_protocol_builder(&yaml, None).unwrap();
         assert_eq!(builder.protocol(), DnsEncryptionProtocol::Https);
 
-        let yaml = YamlLoader::load_from_str(
+        let yaml = yaml_doc!(
             r#"
-            tls_name: "dns.example.com"
-            protocol: "doh"
-        "#,
-        )
-        .unwrap();
-        let builder = as_dns_encryption_protocol_builder(&yaml[0], None).unwrap();
+                tls_name: "dns.example.com"
+                protocol: "doh"
+            "#
+        );
+        let builder = as_dns_encryption_protocol_builder(&yaml, None).unwrap();
         assert_eq!(builder.protocol(), DnsEncryptionProtocol::Https);
 
-        let yaml = YamlLoader::load_from_str(
-            r#"
-            protocol: "tls"
-        "#,
-        )
-        .unwrap();
-        assert!(as_dns_encryption_protocol_builder(&yaml[0], None).is_err());
-
-        let yaml = YamlLoader::load_from_str(
-            r#"
-            tls_name: "example.com"
-            invalid_field: "value"
-        "#,
-        )
-        .unwrap();
-        assert!(as_dns_encryption_protocol_builder(&yaml[0], None).is_err());
-
-        let yaml = YamlLoader::load_from_str(
-            r#"
-            tls_name: "example.com"
-            protocol: "invalid_protocol"
-        "#,
-        )
-        .unwrap();
-        assert!(as_dns_encryption_protocol_builder(&yaml[0], None).is_err());
-
-        assert!(as_dns_encryption_protocol_builder(&Yaml::Boolean(false), None).is_err());
-        assert!(as_dns_encryption_protocol_builder(&Yaml::Integer(42), None).is_err());
-
-        // Invalid string values
-        let yaml = Yaml::String("".to_string());
-        assert!(as_dns_encryption_protocol_builder(&yaml, None).is_err());
-
-        let yaml = Yaml::String("!@#$%^&*()".to_string());
-        assert!(as_dns_encryption_protocol_builder(&yaml, None).is_err());
-
-        // Invalid value type
-        let yaml = Yaml::Null;
-        assert!(as_dns_encryption_protocol_builder(&yaml, None).is_err());
-
-        let temp_dir = temp_dir();
-        let test_dir = temp_dir.join("g3_yaml_test");
-        fs::create_dir_all(&test_dir).unwrap();
-        let cert_path = test_dir.join("test_cert.pem");
-
+        let temp_dir = TempDir::new("g3_yaml_ok");
+        let test_dir_path = temp_dir.path();
+        let cert_path = test_dir_path.join("test_cert.pem");
         let cert_content = r#"-----BEGIN CERTIFICATE-----
 MIIDHzCCAgegAwIBAgIUWcRGf6EVDGnVyfKik4b3B3h/e2AwDQYJKoZIhvcNAQEL
 BQAwGTEXMBUGA1UEAwwOZG5zLmV4YW1wbGUuY29tMB4XDTI0MDUyMjA4MTg0NloX
@@ -171,30 +159,96 @@ VR0TBAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAdpGZ+r6f+e4k/u7v/q8y/s5e
 +g5i/r8k/s4h/u6e+e8h/u5k/v7f/q9z/r8h/s6f+g5i/r8k/s4h/u6e+e8h/u4=
 -----END CERTIFICATE-----"#;
         fs::write(&cert_path, cert_content).unwrap();
-
         let yaml = YamlLoader::load_from_str(&format!(
             r#"
                 tls_name: "example.com"
                 tls_client:
-                  certificate: "{}"
+                    certificate: "{}"
             "#,
             cert_path.file_name().unwrap().to_str().unwrap()
         ))
         .unwrap();
-        let result = as_dns_encryption_protocol_builder(&yaml[0], Some(&test_dir));
+        let result = as_dns_encryption_protocol_builder(&yaml[0], Some(test_dir_path));
         assert!(result.is_ok());
+    }
 
-        let yaml = YamlLoader::load_from_str(
+    #[test]
+    fn as_dns_encryption_protocol_builder_err() {
+        let yaml = yaml_str!("invalid");
+        assert!(as_dns_encryption_protocol(&yaml).is_err());
+
+        let yaml = Yaml::Boolean(true);
+        assert!(as_dns_encryption_protocol(&yaml).is_err());
+
+        let yaml = yaml_doc!(
             r#"
-            tls_name: "example.com"
-            tls_client:
-              certificate: "non_existent_file.pem"
-        "#,
-        )
-        .unwrap();
-        let result = as_dns_encryption_protocol_builder(&yaml[0], Some(&test_dir));
-        assert!(result.is_err());
+                protocol: "tls"
+            "#
+        );
+        assert!(as_dns_encryption_protocol_builder(&yaml, None).is_err());
 
-        let _ = fs::remove_dir_all(&test_dir);
+        let yaml = yaml_doc!(
+            r#"
+                tls_name: "example.com"
+                invalid_field: "value"
+            "#
+        );
+        assert!(as_dns_encryption_protocol_builder(&yaml, None).is_err());
+
+        let yaml = yaml_doc!(
+            r#"
+                tls_name: "example.com"
+                protocol: "invalid_protocol"
+            "#
+        );
+        assert!(as_dns_encryption_protocol_builder(&yaml, None).is_err());
+
+        let yaml = Yaml::Boolean(false);
+        assert!(as_dns_encryption_protocol_builder(&yaml, None).is_err());
+
+        let yaml = Yaml::Integer(42);
+        assert!(as_dns_encryption_protocol_builder(&yaml, None).is_err());
+
+        // Invalid string values
+        let yaml = yaml_str!("");
+        assert!(as_dns_encryption_protocol_builder(&yaml, None).is_err());
+
+        let yaml = yaml_str!("!@#$%^&*()");
+        assert!(as_dns_encryption_protocol_builder(&yaml, None).is_err());
+
+        // Invalid value type
+        let yaml = Yaml::Null;
+        assert!(as_dns_encryption_protocol_builder(&yaml, None).is_err());
+
+        let temp_dir = TempDir::new("g3_yaml_err");
+        let test_dir_path = temp_dir.path();
+        let cert_path = test_dir_path.join("test_cert.pem");
+        let cert_content = r#"-----BEGIN CERTIFICATE-----
+MIIDHzCCAgegAwIBAgIUWcRGf6EVDGnVyfKik4b3B3h/e2AwDQYJKoZIhvcNAQEL
+BQAwGTEXMBUGA1UEAwwOZG5zLmV4YW1wbGUuY29tMB4XDTI0MDUyMjA4MTg0NloX
+DTM0MDUxOTA4MTg0NlowGTEXMBUGA1UEAwwOZG5zLmV4YW1wbGUuY29tMIIBIjAN
+BgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAy1eX6o7dSpuG2b/lWl4i8z2u7T0F
+U4C5J5mU+pRTd85KR2gC5fA1iTRZkvkM2SWLdWY2buYjJey06qf/B6F7pL/+s7s/
+9/bDY8rC8M2B6y419aZg7qYm8+E4qvrA0u0aY5u0u1E8wYpP7t6m3F8g3L2Z6uY4
+t+p8Q+c2C8b8s7x3d8t/g3e5h7k6l+f9i/s3e4k/r7v+w8f+y2e6n/j9o8c7s6k3
+k5i4l8a9i/c3e+p8q+f9k/r8v/s4e+n6u+b9w/r7j/u5f+b8o/q9x/w6e+f7i/v6
+k/t5b+p9s/u3g+d8a+h+k+e+qQIDAQABo1MwUTAdBgNVHQ4EFgQUQ3j1y3v6s8r8
+s+f9d3b7e6r5q+wwHwYDVR0jBBgwFoAUQ3j1y3v6s8r8s+f9d3b7e6r5q+wwDAYD
+VR0TBAUwAwEB/zANBgkqhkiG-w0BAQsFAAOCAQEAdpGZ+r6f+e4k/u7v/q8y/s5e
++e6q/s9g+u8p/u5k/v7f/q9z/r8h/s6f+g5i/r8k/s4h/u6e+e8h/u5k/v7f/q9z
+/r8h/s6f+g5i/r8k/s4h/u6e+e8h/u5k/v7f/q9z/r8h/s6f+g5i/r8k/s4h/u6e
++e8h/u5k/v7f/q9z/r8h/s6f+g5i/r8k/s4h/u6e+e8h/u5k/v7f/q9z/r8h/s6f
++g5i/r8k/s4h/u6e+e8h/u5k/v7f/q9z/r8h/s6f+g5i/r8k/s4h/u6e+e8h/u4=
+-----END CERTIFICATE-----"#;
+        fs::write(&cert_path, cert_content).unwrap();
+        let yaml = yaml_doc!(
+            r#"
+                tls_name: "example.com"
+                tls_client:
+                    certificate: "non_existent_file.pem"
+            "#
+        );
+        let result = as_dns_encryption_protocol_builder(&yaml, Some(test_dir_path));
+        assert!(result.is_err());
     }
 }

--- a/lib/g3-yaml/src/value/net/haproxy.rs
+++ b/lib/g3-yaml/src/value/net/haproxy.rs
@@ -23,16 +23,23 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_as_proxy_protocol_version() {
-        let yaml = Yaml::String("1".to_string());
-        let version = as_proxy_protocol_version(&yaml).unwrap();
-        assert_eq!(version, ProxyProtocolVersion::V1);
+    fn as_proxy_protocol_version_ok() {
+        let yaml = yaml_str!("1");
+        assert_eq!(
+            as_proxy_protocol_version(&yaml).unwrap(),
+            ProxyProtocolVersion::V1
+        );
 
         let yaml = Yaml::Integer(2);
-        let version = as_proxy_protocol_version(&yaml).unwrap();
-        assert_eq!(version, ProxyProtocolVersion::V2);
+        assert_eq!(
+            as_proxy_protocol_version(&yaml).unwrap(),
+            ProxyProtocolVersion::V2
+        );
+    }
 
-        let yaml = Yaml::String("3".to_string()); // Invalid version
+    #[test]
+    fn as_proxy_protocol_version_err() {
+        let yaml = yaml_str!("3"); // Invalid version
         assert!(as_proxy_protocol_version(&yaml).is_err());
 
         let yaml = Yaml::Integer(256); // Beyond u8 range

--- a/lib/g3-yaml/src/value/net/http.rs
+++ b/lib/g3-yaml/src/value/net/http.rs
@@ -152,67 +152,37 @@ mod tests {
     use yaml_rust::YamlLoader;
 
     #[test]
-    fn test_as_http_keepalive_config() {
+    fn as_http_keepalive_config_ok() {
         // Valid config with enable and idle_expire
-        let yaml = YamlLoader::load_from_str(
+        let yaml = yaml_doc!(
             r#"
-            enable: true
-            idle_expire: 30s
-            "#,
-        )
-        .unwrap();
-        let config = as_http_keepalive_config(&yaml[0]).unwrap();
+                enable: true
+                idle_expire: 30s
+            "#
+        );
+        let config = as_http_keepalive_config(&yaml).unwrap();
         assert_eq!(config.is_enabled(), true);
         assert_eq!(config.idle_expire(), Duration::from_secs(30));
 
         // Valid config with only enable
-        let yaml = YamlLoader::load_from_str(
+        let yaml = yaml_doc!(
             r#"
-            enable: false
-            "#,
-        )
-        .unwrap();
-        let config = as_http_keepalive_config(&yaml[0]).unwrap();
+                enable: false
+            "#
+        );
+        let config = as_http_keepalive_config(&yaml).unwrap();
         assert_eq!(config.is_enabled(), false);
         assert_eq!(config.idle_expire(), Duration::from_nanos(0));
 
         // Valid config with only idle_expire
-        let yaml = YamlLoader::load_from_str(
+        let yaml = yaml_doc!(
             r#"
-            idle_expire: 30s
-            "#,
-        )
-        .unwrap();
-        let config = as_http_keepalive_config(&yaml[0]).unwrap();
+                idle_expire: 30s
+            "#
+        );
+        let config = as_http_keepalive_config(&yaml).unwrap();
         assert_eq!(config.is_enabled(), true);
         assert_eq!(config.idle_expire(), Duration::from_secs(30));
-
-        // Invalid config with wrong enable type
-        let yaml = YamlLoader::load_from_str(
-            r#"
-            enable: not_a_bool
-            "#,
-        )
-        .unwrap();
-        assert!(as_http_keepalive_config(&yaml[0]).is_err());
-
-        // Invalid config with wrong idle_expire type
-        let yaml = YamlLoader::load_from_str(
-            r#"
-            idle_expire: not_a_duration
-            "#,
-        )
-        .unwrap();
-        assert!(as_http_keepalive_config(&yaml[0]).is_err());
-
-        // Invalid config with wrong key
-        let yaml = YamlLoader::load_from_str(
-            r#"
-            invalid_key: true
-            "#,
-        )
-        .unwrap();
-        assert!(as_http_keepalive_config(&yaml[0]).is_err());
 
         // Valid config with boolean value
         let yaml = Yaml::Boolean(true);
@@ -220,7 +190,7 @@ mod tests {
         assert_eq!(config.is_enabled(), true);
 
         // Valid config with string value
-        let yaml = Yaml::String("30s".to_string());
+        let yaml = yaml_str!("30s");
         let config = as_http_keepalive_config(&yaml).unwrap();
         assert_eq!(config.is_enabled(), true);
         assert_eq!(config.idle_expire(), Duration::from_secs(30));
@@ -230,6 +200,33 @@ mod tests {
         let config = as_http_keepalive_config(&yaml).unwrap();
         assert_eq!(config.is_enabled(), true);
         assert_eq!(config.idle_expire(), Duration::from_secs(60));
+    }
+
+    #[test]
+    fn as_http_keepalive_config_err() {
+        // Invalid config with wrong enable type
+        let yaml = yaml_doc!(
+            r#"
+                enable: not_a_bool
+            "#
+        );
+        assert!(as_http_keepalive_config(&yaml).is_err());
+
+        // Invalid config with wrong idle_expire type
+        let yaml = yaml_doc!(
+            r#"
+                idle_expire: not_a_duration
+            "#
+        );
+        assert!(as_http_keepalive_config(&yaml).is_err());
+
+        // Invalid config with wrong key
+        let yaml = yaml_doc!(
+            r#"
+                invalid_key: true
+            "#
+        );
+        assert!(as_http_keepalive_config(&yaml).is_err());
 
         // Invalid config with unsupported type
         let yaml = Yaml::Real("not_a_duration".to_string());
@@ -237,7 +234,7 @@ mod tests {
     }
 
     #[test]
-    fn test_as_http_forwarded_header_type() {
+    fn as_http_forwarded_header_type_ok() {
         // Valid config with boolean value
         let yaml = Yaml::Boolean(true);
         let header_type = as_http_forwarded_header_type(&yaml).unwrap();
@@ -248,13 +245,9 @@ mod tests {
         assert_eq!(header_type, HttpForwardedHeaderType::Disable);
 
         // Valid config with string value
-        let yaml = Yaml::String("Standard".to_string());
+        let yaml = yaml_str!("Standard");
         let header_type = as_http_forwarded_header_type(&yaml).unwrap();
         assert_eq!(header_type, HttpForwardedHeaderType::Standard);
-
-        // Invalid config with invalid string value
-        let yaml = Yaml::String("Invalid".to_string());
-        assert!(as_http_forwarded_header_type(&yaml).is_err());
 
         // Valid config with integer value
         let yaml = Yaml::Integer(1);
@@ -264,88 +257,95 @@ mod tests {
         let yaml = Yaml::Integer(0);
         let header_type = as_http_forwarded_header_type(&yaml).unwrap();
         assert_eq!(header_type, HttpForwardedHeaderType::Disable);
+    }
 
+    #[test]
+    fn as_http_forwarded_header_type_err() {
         // Invalid config with unsupported type
         let yaml = Yaml::Null;
+        assert!(as_http_forwarded_header_type(&yaml).is_err());
+
+        // Invalid config with invalid string value
+        let yaml = yaml_str!("Invalid");
         assert!(as_http_forwarded_header_type(&yaml).is_err());
     }
 
     #[test]
-    fn test_as_http_forward_capability() {
+    fn as_http_forward_capability_ok() {
         // Valid config with all forward options enabled
-        let yaml = YamlLoader::load_from_str(
+        let yaml = yaml_doc!(
             r#"
-            forward_https: true
-            forward_ftp: true
-            forward_ftp_get: true
-            forward_ftp_put: true
-            forward_ftp_del: true
-        "#,
-        )
-        .unwrap();
-        let cap = as_http_forward_capability(&yaml[0]).unwrap();
+                forward_https: true
+                forward_ftp: true
+                forward_ftp_get: true
+                forward_ftp_put: true
+                forward_ftp_del: true
+            "#
+        );
+        let cap = as_http_forward_capability(&yaml).unwrap();
         assert!(cap.forward_https());
         assert!(cap.forward_ftp(&Method::GET));
         assert!(cap.forward_ftp(&Method::PUT));
         assert!(cap.forward_ftp(&Method::DELETE));
 
         // Valid config with only HTTPS forwarding enabled
-        let yaml = YamlLoader::load_from_str("{ forward_https: true }").unwrap();
-        let cap = as_http_forward_capability(&yaml[0]).unwrap();
+        let yaml = yaml_doc!("{ forward_https: true }");
+        let cap = as_http_forward_capability(&yaml).unwrap();
         assert!(cap.forward_https());
 
         // Valid config with FTP forwarding enabled
-        let yaml = YamlLoader::load_from_str("{ forward_ftp: true }").unwrap();
-        let cap = as_http_forward_capability(&yaml[0]).unwrap();
+        let yaml = yaml_doc!("{ forward_ftp: true }");
+        let cap = as_http_forward_capability(&yaml).unwrap();
         assert!(cap.forward_ftp(&Method::GET));
         assert!(cap.forward_ftp(&Method::PUT));
         assert!(cap.forward_ftp(&Method::DELETE));
 
-        let yaml = YamlLoader::load_from_str(
+        let yaml = yaml_doc!(
             r#"
-            forward_ftp_get: true
-            forward_ftp_put: false
-            forward_ftp_del: true
-        "#,
-        )
-        .unwrap();
-        let cap = as_http_forward_capability(&yaml[0]).unwrap();
+                forward_ftp_get: true
+                forward_ftp_put: false
+                forward_ftp_del: true
+            "#
+        );
+        let cap = as_http_forward_capability(&yaml).unwrap();
         assert!(cap.forward_ftp(&Method::GET));
         assert!(!cap.forward_ftp(&Method::PUT));
         assert!(cap.forward_ftp(&Method::DELETE));
 
         // Valid config with only FTP GET forwarding enabled
-        let yaml = YamlLoader::load_from_str(
+        let yaml = yaml_doc!(
             r#"
-            forward_ftp: false
-            forward_ftp_get: true
-        "#,
-        )
-        .unwrap();
-        let cap = as_http_forward_capability(&yaml[0]).unwrap();
+                forward_ftp: false
+                forward_ftp_get: true
+            "#
+        );
+        let cap = as_http_forward_capability(&yaml).unwrap();
         assert!(cap.forward_ftp(&Method::GET));
         assert!(!cap.forward_ftp(&Method::PUT));
         assert!(!cap.forward_ftp(&Method::DELETE));
+    }
 
+    #[test]
+    fn as_http_forward_capability_err() {
         // Invalid config with invalid key
-        let yaml = YamlLoader::load_from_str("{ invalid_key: true }").unwrap();
-        assert!(as_http_forward_capability(&yaml[0]).is_err());
+        let yaml = yaml_doc!("{ invalid_key: true }");
+        assert!(as_http_forward_capability(&yaml).is_err());
 
         // Invalid config with wrong value type
-        let yaml = YamlLoader::load_from_str("{ forward_https: not_a_bool }").unwrap();
-        assert!(as_http_forward_capability(&yaml[0]).is_err());
+        let yaml = yaml_doc!("{ forward_https: not_a_bool }");
+        assert!(as_http_forward_capability(&yaml).is_err());
 
-        let yaml = YamlLoader::load_from_str("{ forward_ftp: not_a_bool }").unwrap();
-        assert!(as_http_forward_capability(&yaml[0]).is_err());
+        let yaml = yaml_doc!("{ forward_ftp: not_a_bool }");
+        assert!(as_http_forward_capability(&yaml).is_err());
 
-        let yaml = YamlLoader::load_from_str("{ forward_ftp_get: not_a_bool }").unwrap();
-        assert!(as_http_forward_capability(&yaml[0]).is_err());
+        let yaml = yaml_doc!("{ forward_ftp_get: not_a_bool }");
+        assert!(as_http_forward_capability(&yaml).is_err());
 
-        let yaml = YamlLoader::load_from_str("{ forward_ftp_put: not_a_bool }").unwrap();
-        assert!(as_http_forward_capability(&yaml[0]).is_err());
+        let yaml = yaml_doc!("{ forward_ftp_put: not_a_bool }");
+        assert!(as_http_forward_capability(&yaml).is_err());
 
-        let yaml = YamlLoader::load_from_str("{ forward_ftp_del: not_a_bool }").unwrap();
-        assert!(as_http_forward_capability(&yaml[0]).is_err());
+        let yaml = yaml_doc!("{ forward_ftp_del: not_a_bool }");
+        assert!(as_http_forward_capability(&yaml).is_err());
 
         // Invalid config with unsupported type
         let yaml = Yaml::Null;
@@ -353,26 +353,32 @@ mod tests {
     }
 
     #[test]
-    fn test_as_http_server_id() {
+    fn as_http_server_id_ok() {
         // Valid config with string value
-        let yaml = Yaml::String("server1".to_string());
+        let yaml = yaml_str!("server1");
         let id = as_http_server_id(&yaml).unwrap();
         assert_eq!(id.as_str(), "server1");
+    }
 
+    #[test]
+    fn as_http_server_id_err() {
         // Invalid config with wrong value type
         let yaml = Yaml::Integer(123);
         assert!(as_http_server_id(&yaml).is_err());
     }
 
     #[test]
-    fn test_as_http_header_name() {
+    fn as_http_header_name_ok() {
         // Valid header name
-        let yaml = Yaml::String("Content-Type".to_string());
+        let yaml = yaml_str!("Content-Type");
         let header_name = as_http_header_name(&yaml).unwrap();
         assert_eq!(header_name.as_str(), "content-type");
+    }
 
+    #[test]
+    fn as_http_header_name_err() {
         // Invalid header name
-        let yaml = Yaml::String("Invalid Header".to_string());
+        let yaml = yaml_str!("Invalid Header");
         assert!(as_http_header_name(&yaml).is_err());
 
         // Invalid type
@@ -381,18 +387,21 @@ mod tests {
     }
 
     #[test]
-    fn test_as_http_header_value_string() {
+    fn as_http_header_value_string_ok() {
         // Valid header value
-        let yaml = Yaml::String("text/plain; charset=utf-8".to_string());
+        let yaml = yaml_str!("text/plain; charset=utf-8");
         let value = as_http_header_value_string(&yaml).unwrap();
         assert_eq!(value, "text/plain; charset=utf-8");
 
-        let yaml = Yaml::String("".to_string());
+        let yaml = yaml_str!("");
         let value = as_http_header_value_string(&yaml).unwrap();
         assert_eq!(value, "");
+    }
 
+    #[test]
+    fn as_http_header_value_string_err() {
         // Invalid header value
-        let yaml = Yaml::String("Invalid\x0bValue".to_string());
+        let yaml = yaml_str!("Invalid\x0bValue");
         assert!(as_http_header_value_string(&yaml).is_err());
 
         // Invalid type
@@ -401,14 +410,17 @@ mod tests {
     }
 
     #[test]
-    fn test_as_http_path_and_query() {
+    fn as_http_path_and_query_ok() {
         // Valid path and query
-        let yaml = Yaml::String("/path?query=value".to_string());
+        let yaml = yaml_str!("/path?query=value");
         let path_and_query = as_http_path_and_query(&yaml).unwrap();
         assert_eq!(path_and_query.as_str(), "/path?query=value");
+    }
 
+    #[test]
+    fn as_http_path_and_query_err() {
         // Invalid path and query
-        let yaml = Yaml::String("Invalid Path".to_string());
+        let yaml = yaml_str!("Invalid Path");
         assert!(as_http_path_and_query(&yaml).is_err());
 
         // Invalid type

--- a/lib/g3-yaml/src/value/net/interface.rs
+++ b/lib/g3-yaml/src/value/net/interface.rs
@@ -36,16 +36,19 @@ mod tests {
     const LOOPBACK_INTERFACE: &str = "lo0";
 
     #[test]
-    fn test_as_interface() {
+    fn as_interface_ok() {
         let yaml = Yaml::String(LOOPBACK_INTERFACE.to_string());
         assert_eq!(as_interface(&yaml).unwrap().name(), LOOPBACK_INTERFACE);
-
-        let yaml = Yaml::String("invalid_interface".to_string());
-        assert!(as_interface(&yaml).is_err());
 
         let yaml = Yaml::Integer(1);
         let interface = as_interface(&yaml).unwrap();
         assert_eq!(interface.id().get(), 1);
+    }
+
+    #[test]
+    fn as_interface_err() {
+        let yaml = yaml_str!("invalid_interface");
+        assert!(as_interface(&yaml).is_err());
 
         let yaml = Yaml::Integer(u32::MAX as i64 + 1);
         assert!(as_interface(&yaml).is_err());

--- a/lib/g3-yaml/src/value/net/tcp.rs
+++ b/lib/g3-yaml/src/value/net/tcp.rs
@@ -297,391 +297,287 @@ mod tests {
         HappyEyeballsConfig, TcpConnectConfig, TcpKeepAliveConfig, TcpListenConfig, TcpMiscSockOpts,
     };
 
-    mod test_as_tcp_listen_config {
-        use super::*;
+    #[test]
+    fn as_tcp_listen_config_ok() {
+        let yaml = yaml_doc!("8080");
+        let config = as_tcp_listen_config(&yaml).unwrap();
+        assert_eq!(config.address().port(), 8080);
+        assert_eq!(
+            config.address(),
+            SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 8080)
+        );
 
-        #[test]
-        fn integer_port() {
-            let yaml = yaml_doc!("8080");
-            let config = as_tcp_listen_config(&yaml).unwrap();
-            assert_eq!(config.address().port(), 8080);
-            assert_eq!(
-                config.address(),
-                SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 8080)
-            );
-        }
+        let yaml = yaml_doc!("\"127.0.0.1:8081\"");
+        let config = as_tcp_listen_config(&yaml).unwrap();
+        let expected_addr: SocketAddr = "127.0.0.1:8081".parse().unwrap();
+        assert_eq!(config.address(), expected_addr);
 
-        #[test]
-        fn string_address() {
-            let yaml = yaml_doc!("\"127.0.0.1:8081\"");
-            let config = as_tcp_listen_config(&yaml).unwrap();
-            let expected_addr: SocketAddr = "127.0.0.1:8081".parse().unwrap();
-            assert_eq!(config.address(), expected_addr);
-        }
-
-        #[test]
-        fn hash_full() {
-            let yaml = yaml_doc!(
-                r#"
-                    address: "0.0.0.0:8083"
-                    backlog: 1024
-                    scale: "50%"
-                "#
-            );
-            let config = as_tcp_listen_config(&yaml).unwrap();
-
-            let expected_addr: SocketAddr = "0.0.0.0:8083".parse().unwrap();
-            assert_eq!(config.address(), expected_addr);
-            assert_eq!(config.backlog(), 1024);
-        }
+        let yaml = yaml_doc!(
+            r#"
+                address: "0.0.0.0:8083"
+                backlog: 1024
+                scale: "50%"
+            "#
+        );
+        let config = as_tcp_listen_config(&yaml).unwrap();
+        let expected_addr: SocketAddr = "0.0.0.0:8083".parse().unwrap();
+        assert_eq!(config.address(), expected_addr);
+        assert_eq!(config.backlog(), 1024);
 
         #[cfg(not(target_os = "openbsd"))]
-        #[test]
-        fn hash_ipv6_only_true() {
-            let yaml = yaml_doc!(
-                r#"
-                    address: "[::]:8083"
-                    ipv6_only: true
-                "#
-            );
-            let config = as_tcp_listen_config(&yaml).unwrap();
-            assert_eq!(config.is_ipv6only(), Some(true));
-        }
+        let yaml = yaml_doc!(
+            r#"
+                address: "[::]:8083"
+                ipv6_only: true
+            "#
+        );
+        let config = as_tcp_listen_config(&yaml).unwrap();
+        assert_eq!(config.is_ipv6only(), Some(true));
 
         #[cfg(not(target_os = "openbsd"))]
-        #[test]
-        fn hash_ipv6_only_false() {
-            let yaml = yaml_doc!(
-                r#"
-                    address: "[::]:8084"
-                    ipv6_only: false
-                "#
-            );
-            let config = as_tcp_listen_config(&yaml).unwrap();
-            assert_eq!(config.is_ipv6only(), Some(false));
-        }
+        let yaml = yaml_doc!(
+            r#"
+                address: "[::]:8084"
+                ipv6_only: false
+            "#
+        );
+        let config = as_tcp_listen_config(&yaml).unwrap();
+        assert_eq!(config.is_ipv6only(), Some(false));
 
-        #[test]
-        fn scale_percentage() {
-            let yaml_map = yaml_doc!("scale: \"50%\"");
-            let mut cfg = TcpListenConfig::default();
-            assert!(set_tcp_listen_scale(&mut cfg, &yaml_map["scale"]).is_ok());
-        }
+        let yaml_map = yaml_doc!("scale: \"50%\"");
+        let mut cfg = TcpListenConfig::default();
+        assert!(set_tcp_listen_scale(&mut cfg, &yaml_map["scale"]).is_ok());
 
-        #[test]
-        fn scale_fraction() {
-            let yaml_map = yaml_doc!("scale: \"3/4\"");
-            let mut cfg = TcpListenConfig::default();
-            assert!(set_tcp_listen_scale(&mut cfg, &yaml_map["scale"]).is_ok());
-        }
+        let yaml_map = yaml_doc!("scale: \"3/4\"");
+        let mut cfg = TcpListenConfig::default();
+        assert!(set_tcp_listen_scale(&mut cfg, &yaml_map["scale"]).is_ok());
 
-        #[test]
-        fn scale_float_str() {
-            let yaml_map = yaml_doc!("scale: \"1.5\"");
-            let mut cfg = TcpListenConfig::default();
-            assert!(set_tcp_listen_scale(&mut cfg, &yaml_map["scale"]).is_ok());
-        }
+        let yaml_map = yaml_doc!("scale: \"1.5\"");
+        let mut cfg = TcpListenConfig::default();
+        assert!(set_tcp_listen_scale(&mut cfg, &yaml_map["scale"]).is_ok());
 
-        #[test]
-        fn scale_integer() {
-            let yaml_map = yaml_doc!("scale: 2");
-            let mut cfg = TcpListenConfig::default();
-            assert!(set_tcp_listen_scale(&mut cfg, &yaml_map["scale"]).is_ok());
-        }
+        let yaml_map = yaml_doc!("scale: 2");
+        let mut cfg = TcpListenConfig::default();
+        assert!(set_tcp_listen_scale(&mut cfg, &yaml_map["scale"]).is_ok());
 
-        #[test]
-        fn scale_real() {
-            let yaml_value = Yaml::Real("2.5".to_string());
-            let mut cfg = TcpListenConfig::default();
-            assert!(set_tcp_listen_scale(&mut cfg, &yaml_value).is_ok());
-        }
-
-        #[test]
-        fn invalid_port_too_large() {
-            let yaml = yaml_doc!("70000");
-            assert!(as_tcp_listen_config(&yaml).is_err());
-        }
-
-        #[test]
-        fn invalid_address_format() {
-            let yaml = yaml_doc!("\"not_an_address\"");
-            assert!(as_tcp_listen_config(&yaml).is_err());
-        }
-
-        #[test]
-        fn invalid_scale_type_bool() {
-            let yaml_map = yaml_doc!("scale: true");
-            let mut cfg = TcpListenConfig::default();
-            assert!(set_tcp_listen_scale(&mut cfg, &yaml_map["scale"]).is_err());
-        }
-
-        #[test]
-        fn invalid_scale_percentage_format() {
-            let yaml_map = yaml_doc!("scale: \"abc%\"");
-            let mut cfg = TcpListenConfig::default();
-            assert!(set_tcp_listen_scale(&mut cfg, &yaml_map["scale"]).is_err());
-        }
-
-        #[test]
-        fn invalid_scale_fraction_numerator() {
-            let yaml_map = yaml_doc!("scale: \"a/4\"");
-            let mut cfg = TcpListenConfig::default();
-            assert!(set_tcp_listen_scale(&mut cfg, &yaml_map["scale"]).is_err());
-        }
-
-        #[test]
-        fn invalid_scale_fraction_denominator() {
-            let yaml_map = yaml_doc!("scale: \"3/b\"");
-            let mut cfg = TcpListenConfig::default();
-            assert!(set_tcp_listen_scale(&mut cfg, &yaml_map["scale"]).is_err());
-        }
-
-        #[test]
-        fn invalid_scale_float_str_format() {
-            let yaml_map = yaml_doc!("scale: \"not_a_float\"");
-            let mut cfg = TcpListenConfig::default();
-            assert!(set_tcp_listen_scale(&mut cfg, &yaml_map["scale"]).is_err());
-        }
-
-        #[test]
-        fn invalid_hash_key() {
-            let yaml = yaml_doc!("invalid_key: 123");
-            assert!(as_tcp_listen_config(&yaml).is_err());
-        }
-
-        #[test]
-        fn invalid_top_level_type_array() {
-            let yaml = yaml_doc!("[1, 2, 3]");
-            assert!(as_tcp_listen_config(&yaml).is_err());
-        }
+        let yaml_value = Yaml::Real("2.5".to_string());
+        let mut cfg = TcpListenConfig::default();
+        assert!(set_tcp_listen_scale(&mut cfg, &yaml_value).is_ok());
     }
 
-    mod test_as_tcp_connect_config {
-        use super::*;
+    #[test]
+    fn as_tcp_listen_config_err() {
+        let yaml = yaml_doc!("70000");
+        assert!(as_tcp_listen_config(&yaml).is_err());
 
-        #[test]
-        fn normal_input() {
-            let yaml = yaml_doc!(
-                r#"
-                    max_retry: 5
-                    each_timeout: 10s
-                "#
-            );
-            let config = as_tcp_connect_config(&yaml).unwrap();
-            assert_eq!(config.max_tries(), 6);
-            assert_eq!(config.each_timeout(), Duration::from_secs(10));
-        }
+        let yaml = yaml_doc!("\"not_an_address\"");
+        assert!(as_tcp_listen_config(&yaml).is_err());
 
-        #[test]
-        fn default_values() {
-            let yaml = yaml_doc!("{}");
-            let config = as_tcp_connect_config(&yaml).unwrap();
-            let default_config = TcpConnectConfig::default();
-            assert_eq!(config.max_tries(), default_config.max_tries());
-            assert_eq!(config.each_timeout(), default_config.each_timeout());
-        }
+        let yaml_map = yaml_doc!("scale: true");
+        let mut cfg = TcpListenConfig::default();
+        assert!(set_tcp_listen_scale(&mut cfg, &yaml_map["scale"]).is_err());
 
-        #[test]
-        fn invalid_type_not_map() {
-            let yaml = yaml_doc!("123");
-            assert!(as_tcp_connect_config(&yaml).is_err());
-        }
+        let yaml_map = yaml_doc!("scale: \"abc%\"");
+        let mut cfg = TcpListenConfig::default();
+        assert!(set_tcp_listen_scale(&mut cfg, &yaml_map["scale"]).is_err());
 
-        #[test]
-        fn invalid_key() {
-            let yaml = yaml_doc!("unknown_key: 100");
-            assert!(as_tcp_connect_config(&yaml).is_err());
-        }
+        let yaml_map = yaml_doc!("scale: \"a/4\"");
+        let mut cfg = TcpListenConfig::default();
+        assert!(set_tcp_listen_scale(&mut cfg, &yaml_map["scale"]).is_err());
 
-        #[test]
-        fn invalid_max_retry_type() {
-            let yaml = yaml_doc!("max_retry: \"not_a_number\"");
-            assert!(as_tcp_connect_config(&yaml).is_err());
-        }
+        let yaml_map = yaml_doc!("scale: \"3/b\"");
+        let mut cfg = TcpListenConfig::default();
+        assert!(set_tcp_listen_scale(&mut cfg, &yaml_map["scale"]).is_err());
 
-        #[test]
-        fn invalid_each_timeout_type() {
-            let yaml = yaml_doc!("each_timeout: \"not_a_duration\"");
-            assert!(as_tcp_connect_config(&yaml).is_err());
-        }
+        let yaml_map = yaml_doc!("scale: \"not_a_float\"");
+        let mut cfg = TcpListenConfig::default();
+        assert!(set_tcp_listen_scale(&mut cfg, &yaml_map["scale"]).is_err());
+
+        let yaml = yaml_doc!("invalid_key: 123");
+        assert!(as_tcp_listen_config(&yaml).is_err());
+
+        let yaml = yaml_doc!("[1, 2, 3]");
+        assert!(as_tcp_listen_config(&yaml).is_err());
     }
 
-    mod test_as_happy_eyeballs_config {
-        use super::*;
+    #[test]
+    fn as_tcp_connect_config_ok() {
+        let yaml = yaml_doc!(
+            r#"
+                max_retry: 5
+                each_timeout: 10s
+            "#
+        );
+        let config = as_tcp_connect_config(&yaml).unwrap();
+        assert_eq!(config.max_tries(), 6);
+        assert_eq!(config.each_timeout(), Duration::from_secs(10));
 
-        #[test]
-        fn normal_input() {
-            let yaml = yaml_doc!(
-                r#"
-                    resolution_delay: 50ms
-                    second_resolution_timeout: 1s
-                    first_address_family_count: 2
-                    connection_attempt_delay: 25ms
-                "#
-            );
-            let config = as_happy_eyeballs_config(&yaml).unwrap();
-            assert_eq!(config.resolution_delay(), Duration::from_millis(50));
-            assert_eq!(config.second_resolution_timeout(), Duration::from_secs(1));
-            assert_eq!(config.first_address_family_count(), 2);
-        }
-
-        #[test]
-        fn default_values() {
-            let yaml = yaml_doc!("{}");
-            let config = as_happy_eyeballs_config(&yaml).unwrap();
-            let default_config = HappyEyeballsConfig::default();
-            assert_eq!(config.resolution_delay(), default_config.resolution_delay());
-            assert_eq!(
-                config.second_resolution_timeout(),
-                default_config.second_resolution_timeout()
-            );
-            assert_eq!(
-                config.first_address_family_count(),
-                default_config.first_address_family_count()
-            );
-            assert_eq!(
-                config.connection_attempt_delay(),
-                default_config.connection_attempt_delay()
-            );
-        }
-
-        #[test]
-        fn invalid_type_not_map() {
-            let yaml = yaml_doc!("\"string_value\"");
-            assert!(as_happy_eyeballs_config(&yaml).is_err());
-        }
-
-        #[test]
-        fn invalid_key() {
-            let yaml = yaml_doc!("bad_key: true");
-            assert!(as_happy_eyeballs_config(&yaml).is_err());
-        }
-
-        #[test]
-        fn invalid_negative_delay() {
-            let yaml = yaml_doc!("resolution_delay: \"-1s\"");
-            assert!(as_happy_eyeballs_config(&yaml).is_err());
-        }
+        let yaml = yaml_doc!("{}");
+        let config = as_tcp_connect_config(&yaml).unwrap();
+        let default_config = TcpConnectConfig::default();
+        assert_eq!(config.max_tries(), default_config.max_tries());
+        assert_eq!(config.each_timeout(), default_config.each_timeout());
     }
 
-    mod test_as_tcp_keepalive_config {
-        use super::*;
+    #[test]
+    fn as_tcp_connect_config_err() {
+        let yaml = yaml_doc!("123");
+        assert!(as_tcp_connect_config(&yaml).is_err());
 
-        #[test]
-        fn hash_input_full() {
-            let yaml = yaml_doc!(
-                r#"
-                    enable: true
-                    idle_time: 300s
-                    probe_interval: 10s
-                    probe_count: 5
-                "#
-            );
-            let config = as_tcp_keepalive_config(&yaml).unwrap();
-            assert!(config.is_enabled());
-            assert_eq!(config.idle_time(), Duration::from_secs(300));
-            assert_eq!(config.probe_interval(), Some(Duration::from_secs(10)));
-            assert_eq!(config.probe_count(), Some(5));
-        }
+        let yaml = yaml_doc!("unknown_key: 100");
+        assert!(as_tcp_connect_config(&yaml).is_err());
 
-        #[test]
-        fn boolean_input_true() {
-            let yaml = yaml_doc!("true");
-            let config = as_tcp_keepalive_config(&yaml).unwrap();
-            assert!(config.is_enabled());
-            let default_tcp_ka_config = TcpKeepAliveConfig::default();
-            assert_eq!(config.idle_time(), default_tcp_ka_config.idle_time());
-        }
+        let yaml = yaml_doc!("max_retry: \"not_a_number\"");
+        assert!(as_tcp_connect_config(&yaml).is_err());
 
-        #[test]
-        fn boolean_input_false() {
-            let yaml = yaml_doc!("false");
-            let config = as_tcp_keepalive_config(&yaml).unwrap();
-            assert!(!config.is_enabled());
-        }
-
-        #[test]
-        fn duration_string_input() {
-            let yaml = yaml_doc!("\"120s\"");
-            let config = as_tcp_keepalive_config(&yaml).unwrap();
-            assert!(config.is_enabled());
-            assert_eq!(config.idle_time(), Duration::from_secs(120));
-        }
-
-        #[test]
-        fn hash_input_only_enable_false() {
-            let yaml = yaml_doc!("enable: false");
-            let config = as_tcp_keepalive_config(&yaml).unwrap();
-            assert!(!config.is_enabled());
-        }
-
-        #[test]
-        fn invalid_hash_key() {
-            let yaml = yaml_doc!("unknown_field: 10s");
-            assert!(as_tcp_keepalive_config(&yaml).is_err());
-        }
+        let yaml = yaml_doc!("each_timeout: \"not_a_duration\"");
+        assert!(as_tcp_connect_config(&yaml).is_err());
     }
 
-    mod test_as_tcp_misc_sock_opts {
-        use super::*;
+    #[test]
+    fn as_happy_eyeballs_config_ok() {
+        let yaml = yaml_doc!(
+            r#"
+                resolution_delay: 50ms
+                second_resolution_timeout: 1s
+                first_address_family_count: 2
+                connection_attempt_delay: 25ms
+            "#
+        );
+        let config = as_happy_eyeballs_config(&yaml).unwrap();
+        assert_eq!(config.resolution_delay(), Duration::from_millis(50));
+        assert_eq!(config.second_resolution_timeout(), Duration::from_secs(1));
+        assert_eq!(config.first_address_family_count(), 2);
+        assert_eq!(
+            config.connection_attempt_delay(),
+            Duration::from_millis(100)
+        );
 
-        #[test]
-        fn normal_input_full() {
-            let yaml = yaml_doc!(
-                r#"
-                    no_delay: true
-                    max_segment_size: 1460
-                    time_to_live: 64
-                    type_of_service: 0x10
-                "#
-            );
-            let config = as_tcp_misc_sock_opts(&yaml).unwrap();
-            assert_eq!(config.no_delay, Some(true));
-            assert_eq!(config.max_segment_size, Some(1460));
-            assert_eq!(config.time_to_live, Some(64));
-            assert_eq!(config.type_of_service, Some(0x10));
-        }
+        let yaml = yaml_doc!("{}");
+        let config = as_happy_eyeballs_config(&yaml).unwrap();
+        let default_config = HappyEyeballsConfig::default();
+        assert_eq!(config.resolution_delay(), default_config.resolution_delay());
+        assert_eq!(
+            config.second_resolution_timeout(),
+            default_config.second_resolution_timeout()
+        );
+        assert_eq!(
+            config.first_address_family_count(),
+            default_config.first_address_family_count()
+        );
+        assert_eq!(
+            config.connection_attempt_delay(),
+            default_config.connection_attempt_delay()
+        );
+    }
 
-        #[test]
-        fn default_values() {
-            let yaml = yaml_doc!("{}");
-            let config = as_tcp_misc_sock_opts(&yaml).unwrap();
-            let default_config = TcpMiscSockOpts::default();
-            assert_eq!(config.no_delay, default_config.no_delay);
-            assert_eq!(config.max_segment_size, default_config.max_segment_size);
-            assert_eq!(config.time_to_live, default_config.time_to_live);
-            assert_eq!(config.type_of_service, default_config.type_of_service);
-            assert_eq!(config.netfilter_mark, default_config.netfilter_mark);
-        }
+    #[test]
+    fn as_happy_eyeballs_config_err() {
+        let yaml = yaml_doc!("\"string_value\"");
+        assert!(as_happy_eyeballs_config(&yaml).is_err());
 
-        #[test]
-        fn invalid_type_not_map() {
-            let yaml = yaml_doc!("\"some_string\"");
-            assert!(as_tcp_misc_sock_opts(&yaml).is_err());
-        }
+        let yaml = yaml_doc!("bad_key: true");
+        assert!(as_happy_eyeballs_config(&yaml).is_err());
 
-        #[test]
-        fn invalid_key() {
-            let yaml = yaml_doc!("unsupported_opt: 1");
-            assert!(as_tcp_misc_sock_opts(&yaml).is_err());
-        }
+        let yaml = yaml_doc!("resolution_delay: \"-1s\"");
+        assert!(as_happy_eyeballs_config(&yaml).is_err());
+    }
 
-        #[test]
-        fn invalid_no_delay_type() {
-            let yaml = yaml_doc!("no_delay: \"true_string\"");
-            assert!(as_tcp_misc_sock_opts(&yaml).is_err());
-        }
+    #[test]
+    fn as_tcp_keepalive_config_ok() {
+        let yaml = yaml_doc!(
+            r#"
+                enable: true
+                idle_time: 300s
+                probe_interval: 10s
+                probe_count: 5
+            "#
+        );
+        let config = as_tcp_keepalive_config(&yaml).unwrap();
+        assert!(config.is_enabled());
+        assert_eq!(config.idle_time(), Duration::from_secs(300));
+        assert_eq!(config.probe_interval(), Some(Duration::from_secs(10)));
+        assert_eq!(config.probe_count(), Some(5));
 
-        #[test]
-        fn invalid_mss_type() {
-            let yaml = yaml_doc!("max_segment_size: \"1460s\"");
-            assert!(as_tcp_misc_sock_opts(&yaml).is_err());
-        }
+        let yaml = yaml_doc!("true");
+        let config = as_tcp_keepalive_config(&yaml).unwrap();
+        assert!(config.is_enabled());
+        let default_tcp_ka_config = TcpKeepAliveConfig::default();
+        assert_eq!(config.idle_time(), default_tcp_ka_config.idle_time());
 
-        #[test]
-        fn invalid_tos_type() {
-            let yaml = yaml_doc!("type_of_service: \"not_u8\"");
-            assert!(as_tcp_misc_sock_opts(&yaml).is_err());
-        }
+        let yaml = yaml_doc!("false");
+        let config = as_tcp_keepalive_config(&yaml).unwrap();
+        assert!(!config.is_enabled());
+
+        let yaml = yaml_doc!("\"120s\"");
+        let config = as_tcp_keepalive_config(&yaml).unwrap();
+        assert!(config.is_enabled());
+        assert_eq!(config.idle_time(), Duration::from_secs(120));
+
+        let yaml = yaml_doc!("enable: false");
+        let config = as_tcp_keepalive_config(&yaml).unwrap();
+        assert!(!config.is_enabled());
+    }
+
+    #[test]
+    fn as_tcp_keepalive_config_err() {
+        let yaml = yaml_doc!("unknown_field: 10s");
+        assert!(as_tcp_keepalive_config(&yaml).is_err());
+
+        let yaml = yaml_doc!("idle_time: -1s");
+        assert!(as_tcp_keepalive_config(&yaml).is_err());
+
+        let yaml = yaml_doc!("probe_interval: -1s");
+        assert!(as_tcp_keepalive_config(&yaml).is_err());
+
+        let yaml = yaml_doc!("probe_count: -1");
+        assert!(as_tcp_keepalive_config(&yaml).is_err());
+
+        let yaml = yaml_doc!("enable: \"not_a_bool\"");
+        assert!(as_tcp_keepalive_config(&yaml).is_err());
+    }
+
+    #[test]
+    fn as_tcp_misc_sock_opts_ok() {
+        let yaml = yaml_doc!(
+            r#"
+                no_delay: true
+                max_segment_size: 1460
+                time_to_live: 64
+                type_of_service: 0x10
+            "#
+        );
+        let config = as_tcp_misc_sock_opts(&yaml).unwrap();
+        assert_eq!(config.no_delay, Some(true));
+        assert_eq!(config.max_segment_size, Some(1460));
+        assert_eq!(config.time_to_live, Some(64));
+        assert_eq!(config.type_of_service, Some(0x10));
+
+        let yaml = yaml_doc!("{}");
+        let config = as_tcp_misc_sock_opts(&yaml).unwrap();
+        let default_config = TcpMiscSockOpts::default();
+        assert_eq!(config.no_delay, default_config.no_delay);
+        assert_eq!(config.max_segment_size, default_config.max_segment_size);
+        assert_eq!(config.time_to_live, default_config.time_to_live);
+        assert_eq!(config.type_of_service, default_config.type_of_service);
+        assert_eq!(config.netfilter_mark, default_config.netfilter_mark);
+    }
+
+    #[test]
+    fn as_tcp_misc_sock_opts_err() {
+        let yaml = yaml_doc!("\"some_string\"");
+        assert!(as_tcp_misc_sock_opts(&yaml).is_err());
+
+        let yaml = yaml_doc!("unsupported_opt: 1");
+        assert!(as_tcp_misc_sock_opts(&yaml).is_err());
+
+        let yaml = yaml_doc!("no_delay: \"true_string\"");
+        assert!(as_tcp_misc_sock_opts(&yaml).is_err());
+
+        let yaml = yaml_doc!("max_segment_size: \"1460s\"");
+        assert!(as_tcp_misc_sock_opts(&yaml).is_err());
+
+        let yaml = yaml_doc!("type_of_service: \"not_u8\"");
+        assert!(as_tcp_misc_sock_opts(&yaml).is_err());
     }
 }


### PR DESCRIPTION
- Renamed test functions for clarity and consistency across modules.
- Improved test cases for `as_proxy_protocol_version`, `as_http_keepalive_config`, `as_tcp_listen_config`, `as_tcp_connect_config`, and others to enhance readability and maintainability.
- Consolidated valid and invalid test cases into separate functions for better organization.
- Updated YAML loading to use `yaml_doc!` macro for consistency.
- Removed redundant comments and unused test cases to streamline the code.