### PR TITLE
test(g3-yaml): Add unit tests for YAML value parsing functions

### DIFF
--- a/lib/g3-yaml/src/value/primary.rs
+++ b/lib/g3-yaml/src/value/primary.rs
@@ -222,23 +222,564 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use yaml_rust::YamlLoader;
 
     #[test]
-    fn t_string() {
-        let v = Yaml::String("123.0".to_string());
-        let pv = as_string(&v).unwrap();
-        assert_eq!(pv, "123.0");
+    fn as_u8_ok() {
+        // valid string input
+        let v = yaml_str!("100");
+        assert_eq!(as_u8(&v).unwrap(), 100);
 
+        // valid integer input
+        let v = Yaml::Integer(200);
+        assert_eq!(as_u8(&v).unwrap(), 200);
+
+        // boundary value (max u8)
+        let v = Yaml::Integer(255);
+        assert_eq!(as_u8(&v).unwrap(), 255);
+    }
+
+    #[test]
+    fn as_u8_err() {
+        // overflow
+        let v = Yaml::Integer(256);
+        assert!(as_u8(&v).is_err());
+
+        // negative number
+        let v = Yaml::Integer(-1);
+        assert!(as_u8(&v).is_err());
+
+        // invalid type
+        let v = Yaml::Boolean(true);
+        assert!(as_u8(&v).is_err());
+
+        // parse error
+        let v = yaml_str!("abc");
+        assert!(as_u8(&v).is_err());
+    }
+
+    #[test]
+    fn as_u16_ok() {
+        // valid string input
+        let v = yaml_str!("50000");
+        assert_eq!(as_u16(&v).unwrap(), 50000);
+
+        // valid integer input
+        let v = Yaml::Integer(60000);
+        assert_eq!(as_u16(&v).unwrap(), 60000);
+
+        // boundary value (max u16)
+        let v = Yaml::Integer(65535);
+        assert_eq!(as_u16(&v).unwrap(), 65535);
+    }
+
+    #[test]
+    fn as_u16_err() {
+        // overflow
+        let v = Yaml::Integer(65536);
+        assert!(as_u16(&v).is_err());
+
+        // negative number
+        let v = Yaml::Integer(-1);
+        assert!(as_u16(&v).is_err());
+
+        // invalid type
+        let v = Yaml::Boolean(false);
+        assert!(as_u16(&v).is_err());
+
+        // parse error
+        let v = yaml_str!("def");
+        assert!(as_u16(&v).is_err());
+    }
+
+    #[test]
+    fn as_u32_ok() {
+        // valid string input
+        let v = yaml_str!("4000000000");
+        assert_eq!(as_u32(&v).unwrap(), 4000000000);
+
+        // valid integer input
+        let v = Yaml::Integer(2000000000);
+        assert_eq!(as_u32(&v).unwrap(), 2000000000);
+
+        // boundary value (max u32)
+        let v = Yaml::Integer(4294967295);
+        assert_eq!(as_u32(&v).unwrap(), 4294967295);
+    }
+
+    #[test]
+    fn as_u32_err() {
+        // overflow
+        let v = Yaml::Integer(4294967296);
+        assert!(as_u32(&v).is_err());
+
+        // negative number
+        let v = Yaml::Integer(-1);
+        assert!(as_u32(&v).is_err());
+
+        // invalid type
+        let v = Yaml::Null;
+        assert!(as_u32(&v).is_err());
+
+        // parse error
+        let v = yaml_str!("ghi");
+        assert!(as_u32(&v).is_err());
+    }
+
+    #[test]
+    fn as_nonzero_u32_ok() {
+        // valid string input
+        let v = yaml_str!("1");
+        assert_eq!(as_nonzero_u32(&v).unwrap(), NonZeroU32::new(1).unwrap());
+
+        // valid integer input
+        let v = Yaml::Integer(2);
+        assert_eq!(as_nonzero_u32(&v).unwrap(), NonZeroU32::new(2).unwrap());
+
+        // boundary value (max u32)
+        let v = Yaml::Integer(4294967295);
+        assert_eq!(
+            as_nonzero_u32(&v).unwrap(),
+            NonZeroU32::new(4294967295).unwrap()
+        );
+    }
+
+    #[test]
+    fn as_nonzero_u32_err() {
+        // overflow
+        let v = Yaml::Integer(4294967296);
+        assert!(as_nonzero_u32(&v).is_err());
+
+        // zero value
+        let v = yaml_str!("0");
+        assert!(as_nonzero_u32(&v).is_err());
+
+        // negative number
+        let v = Yaml::Integer(-1);
+        assert!(as_nonzero_u32(&v).is_err());
+
+        // invalid type
+        let v = Yaml::Array(vec![]);
+        assert!(as_nonzero_u32(&v).is_err());
+
+        // parse error
+        let v = yaml_str!("jkl");
+        assert!(as_nonzero_u32(&v).is_err());
+    }
+
+    #[test]
+    fn as_u64_ok() {
+        // valid string input
+        let v = yaml_str!("18446744073709551615");
+        assert_eq!(as_u64(&v).unwrap(), 18446744073709551615);
+
+        // valid integer input
+        let v = Yaml::Integer(8446744073709551615);
+        assert_eq!(as_u64(&v).unwrap(), 8446744073709551615);
+    }
+
+    #[test]
+    fn as_u64_err() {
+        // overflow
+        let v = yaml_str!("18446744073709551616");
+        assert!(as_u64(&v).is_err());
+
+        // negative number
+        let v = Yaml::Integer(-1);
+        assert!(as_u64(&v).is_err());
+
+        // invalid type
+        let v = Yaml::Boolean(false);
+        assert!(as_u64(&v).is_err());
+
+        // parse error
+        let v = yaml_str!("mno");
+        assert!(as_u64(&v).is_err());
+    }
+
+    #[test]
+    fn as_i32_ok() {
+        // valid string input
+        let v = yaml_str!("-2147483648");
+        assert_eq!(as_i32(&v).unwrap(), -2147483648);
+
+        let v = yaml_str!("0");
+        assert_eq!(as_i32(&v).unwrap(), 0);
+
+        // valid integer input
+        let v = Yaml::Integer(2147483647);
+        assert_eq!(as_i32(&v).unwrap(), 2147483647);
+    }
+
+    #[test]
+    fn as_i32_err() {
+        // overflow
+        let v = Yaml::Integer(2147483648);
+        assert!(as_i32(&v).is_err());
+
+        // underflow
+        let v = Yaml::Integer(-2147483649);
+        assert!(as_i32(&v).is_err());
+
+        // invalid type
+        let v = Yaml::Boolean(true);
+        assert!(as_i32(&v).is_err());
+
+        // parse error
+        let v = yaml_str!("pqr");
+        assert!(as_i32(&v).is_err());
+    }
+
+    #[test]
+    fn as_nonzero_i32_ok() {
+        // valid positive value
+        let v = yaml_str!(1);
+        assert_eq!(as_nonzero_i32(&v).unwrap(), NonZeroI32::new(1).unwrap());
+
+        let v = Yaml::Integer(2147483647);
+        assert_eq!(
+            as_nonzero_i32(&v).unwrap(),
+            NonZeroI32::new(2147483647).unwrap()
+        );
+
+        // valid negative value
+        let v = yaml_str!(-1);
+        assert_eq!(as_nonzero_i32(&v).unwrap(), NonZeroI32::new(-1).unwrap());
+
+        let v = Yaml::Integer(-2147483648);
+        assert_eq!(
+            as_nonzero_i32(&v).unwrap(),
+            NonZeroI32::new(-2147483648).unwrap()
+        );
+    }
+
+    #[test]
+    fn as_nonzero_i32_err() {
+        // zero value
+        let v = yaml_str!("0");
+        assert!(as_nonzero_i32(&v).is_err());
+
+        // overflow
+        let v = Yaml::Integer(2147483648);
+        assert!(as_nonzero_i32(&v).is_err());
+
+        // underflow
+        let v = Yaml::Integer(-2147483649);
+        assert!(as_nonzero_i32(&v).is_err());
+
+        // invalid type
+        let v = Yaml::Null;
+        assert!(as_nonzero_i32(&v).is_err());
+
+        // parse error
+        let v = yaml_str!("stu");
+        assert!(as_nonzero_i32(&v).is_err());
+    }
+
+    #[test]
+    fn as_i64_ok() {
+        // valid string input
+        let v = yaml_str!("-9223372036854775808");
+        assert_eq!(as_i64(&v).unwrap(), -9223372036854775808);
+
+        let v = yaml_str!("0");
+        assert_eq!(as_i64(&v).unwrap(), 0);
+
+        // valid integer input
+        let v = Yaml::Integer(9223372036854775807);
+        assert_eq!(as_i64(&v).unwrap(), 9223372036854775807);
+    }
+
+    #[test]
+    fn as_i64_err() {
+        // overflow
+        let v = yaml_str!("9223372036854775808");
+        assert!(as_i64(&v).is_err());
+
+        // underflow
+        let v = yaml_str!("-9223372036854775809");
+        assert!(as_i64(&v).is_err());
+
+        // invalid type
+        let v = Yaml::Real("1.234e10".into());
+        assert!(as_i64(&v).is_err());
+
+        // parse error
+        let v = yaml_str!("xyz");
+        assert!(as_i64(&v).is_err());
+    }
+
+    #[test]
+    fn as_f64_ok() {
+        // valid string input
+        let v = yaml_str!("3.141592653589793");
+        assert_eq!(as_f64(&v).unwrap(), std::f64::consts::PI);
+
+        // valid integer input
+        let v = Yaml::Integer(42);
+        assert_eq!(as_f64(&v).unwrap(), 42.0);
+
+        // valid real input
+        let v = Yaml::Real("1.234e10".into());
+        assert_eq!(as_f64(&v).unwrap(), 1.234e10);
+    }
+
+    #[test]
+    fn as_f64_err() {
+        // invalid string
+        let v = yaml_str!("not a number");
+        assert!(as_f64(&v).is_err());
+
+        // invalid type
+        let v = Yaml::Boolean(true);
+        assert!(as_f64(&v).is_err());
+    }
+
+    #[test]
+    fn as_bool_ok() {
+        // truthy strings
+        assert!(as_bool(&yaml_str!("on")).unwrap());
+        assert!(as_bool(&yaml_str!("true")).unwrap());
+        assert!(as_bool(&yaml_str!("yes")).unwrap());
+        assert!(as_bool(&yaml_str!("1")).unwrap());
+
+        // falsy strings
+        assert!(!as_bool(&yaml_str!("off")).unwrap());
+        assert!(!as_bool(&yaml_str!("false")).unwrap());
+        assert!(!as_bool(&yaml_str!("no")).unwrap());
+        assert!(!as_bool(&yaml_str!("0")).unwrap());
+
+        // boolean values
+        assert!(as_bool(&Yaml::Boolean(true)).unwrap());
+        assert!(!as_bool(&Yaml::Boolean(false)).unwrap());
+
+        // integer values
+        assert!(as_bool(&Yaml::Integer(1)).unwrap());
+        assert!(!as_bool(&Yaml::Integer(0)).unwrap());
+    }
+
+    #[test]
+    fn as_bool_err() {
+        // invalid string
+        let v = yaml_str!("maybe");
+        assert!(as_bool(&v).is_err());
+
+        // invalid type
+        let v = Yaml::Real("123.45".into());
+        assert!(as_bool(&v).is_err());
+    }
+
+    #[test]
+    fn as_nonzero_isize_ok() {
+        // positive value
+        let v = Yaml::Integer(1);
+        assert_eq!(as_nonzero_isize(&v).unwrap(), NonZeroIsize::new(1).unwrap());
+
+        let v = yaml_str!("2");
+        assert_eq!(as_nonzero_isize(&v).unwrap(), NonZeroIsize::new(2).unwrap());
+
+        // negative value
+        let v = Yaml::Integer(-1);
+        assert_eq!(
+            as_nonzero_isize(&v).unwrap(),
+            NonZeroIsize::new(-1).unwrap()
+        );
+
+        let v = yaml_str!("-2");
+        assert_eq!(
+            as_nonzero_isize(&v).unwrap(),
+            NonZeroIsize::new(-2).unwrap()
+        );
+    }
+
+    #[test]
+    fn as_nonzero_isize_err() {
+        // zero value
+        let v = Yaml::Integer(0);
+        assert!(as_nonzero_isize(&v).is_err());
+
+        let v = yaml_str!("0");
+        assert!(as_nonzero_isize(&v).is_err());
+
+        // invalid type
+        let v = Yaml::Null;
+        assert!(as_nonzero_isize(&v).is_err());
+    }
+
+    #[test]
+    fn as_usize_ok() {
+        // valid string input
+        let v = yaml_str!("100");
+        assert_eq!(as_usize(&v).unwrap(), 100);
+
+        // valid integer input
+        let v = Yaml::Integer(200);
+        assert_eq!(as_usize(&v).unwrap(), 200);
+    }
+
+    #[test]
+    fn as_usize_err() {
+        // negative number
+        let v = Yaml::Integer(-1);
+        assert!(as_usize(&v).is_err());
+
+        // invalid type
+        let v = Yaml::Array(vec![]);
+        assert!(as_usize(&v).is_err());
+    }
+
+    #[test]
+    fn as_nonzero_usize_ok() {
+        // valid string input
+        let v = yaml_str!("1");
+        assert_eq!(as_nonzero_usize(&v).unwrap(), NonZeroUsize::new(1).unwrap());
+
+        // valid integer input
+        let v = Yaml::Integer(2);
+        assert_eq!(as_nonzero_usize(&v).unwrap(), NonZeroUsize::new(2).unwrap());
+    }
+
+    #[test]
+    fn as_nonzero_usize_err() {
+        // zero value
+        let v = yaml_str!("0");
+        assert!(as_nonzero_usize(&v).is_err());
+
+        // negative number
+        let v = Yaml::Integer(-1);
+        assert!(as_nonzero_usize(&v).is_err());
+
+        // invalid type
+        let v = Yaml::Null;
+        assert!(as_nonzero_usize(&v).is_err());
+    }
+
+    #[test]
+    fn as_ascii_ok() {
+        // valid ASCII string
+        let v = yaml_str!("hello");
+        assert_eq!(as_ascii(&v).unwrap().as_str(), "hello");
+    }
+
+    #[test]
+    fn as_ascii_err() {
+        // non-ASCII string
+        let v = yaml_str!("héllo");
+        assert!(as_ascii(&v).is_err());
+
+        let v = yaml_str!("你好");
+        assert!(as_ascii(&v).is_err());
+
+        // invalid type
+        let v = Yaml::Array(vec![]);
+        assert!(as_ascii(&v).is_err());
+    }
+
+    #[test]
+    fn as_string_ok() {
+        // Valid string
+        let v = yaml_str!("123.0");
+        assert_eq!(as_string(&v).unwrap(), "123.0");
+
+        // Valid integer
         let v = Yaml::Integer(123);
-        let pv = as_string(&v).unwrap();
-        assert_eq!(pv, "123");
+        assert_eq!(as_string(&v).unwrap(), "123");
 
+        // Valid negative integer
         let v = Yaml::Integer(-123);
-        let pv = as_string(&v).unwrap();
-        assert_eq!(pv, "-123");
+        assert_eq!(as_string(&v).unwrap(), "-123");
 
-        let v = Yaml::Real("123.0".to_string());
-        let pv = as_string(&v).unwrap();
-        assert_eq!(pv, "123.0");
+        // Valid real number
+        let v = Yaml::Real("123.0".into());
+        assert_eq!(as_string(&v).unwrap(), "123.0");
+    }
+
+    #[test]
+    fn as_string_err() {
+        // Invalid type (boolean)
+        let v = Yaml::Boolean(true);
+        assert!(as_string(&v).is_err());
+
+        // Invalid type (null)
+        let v = Yaml::Null;
+        assert!(as_string(&v).is_err());
+    }
+
+    #[test]
+    fn as_list_ok() {
+        // array input
+        let v = Yaml::Array(vec![Yaml::Integer(1), Yaml::Integer(2), Yaml::Integer(3)]);
+        assert_eq!(as_list(&v, as_i32).unwrap(), vec![1, 2, 3]);
+
+        let v = yaml_doc!("[-1, -2, -3]");
+        assert_eq!(as_list(&v, as_i32).unwrap(), vec![-1, -2, -3]);
+
+        // single value
+        let v = yaml_doc!("42");
+        assert_eq!(as_list(&v, as_i32).unwrap(), vec![42]);
+    }
+
+    #[test]
+    fn as_list_err() {
+        // conversion error in element
+        let v = Yaml::Array(vec![
+            Yaml::Integer(1),
+            Yaml::Boolean(true),
+            Yaml::Integer(3),
+        ]);
+        assert!(as_list::<i32, _>(&v, as_i32).is_err());
+
+        let v = yaml_doc!("[1, 2, 3, x]");
+        assert!(as_list::<i32, _>(&v, as_i32).is_err());
+
+        // invalid single value
+        let v = yaml_doc!("notanumber");
+        assert!(as_list::<i32, _>(&v, as_i32).is_err());
+
+        // invalid type
+        let v = Yaml::Null;
+        assert!(as_list::<i32, _>(&v, as_i32).is_err());
+    }
+
+    #[test]
+    fn as_hashmap_ok() {
+        // valid map
+        let v = yaml_doc!(
+            "
+            key1: 1
+            key2: 2
+            "
+        );
+        let result = as_hashmap(&v, as_string, as_i32).unwrap();
+        assert_eq!(result.get("key1").unwrap(), &1);
+        assert_eq!(result.get("key2").unwrap(), &2);
+
+        let v = yaml_doc!("key: value");
+        assert_eq!(
+            as_hashmap(&v, as_string, as_string)
+                .unwrap()
+                .get("key")
+                .unwrap(),
+            "value"
+        );
+
+        // empty map
+        let v = yaml_doc!("{}");
+        assert_eq!(as_hashmap(&v, as_string, as_i32).unwrap().len(), 0);
+    }
+
+    #[test]
+    fn as_hashmap_err() {
+        // non-key
+        let v = yaml_doc!(": value");
+        assert!(as_hashmap(&v, as_string, as_string).is_err());
+
+        // invalid value
+        let v = yaml_doc!("key: not_a_number");
+        assert!(as_hashmap(&v, as_string, as_i32).is_err());
+
+        // invalid type
+        let v = Yaml::Null;
+        assert!(as_hashmap(&v, as_string, as_i32).is_err());
     }
 }

--- a/lib/g3-yaml/src/value/random.rs
+++ b/lib/g3-yaml/src/value/random.rs
@@ -45,3 +45,94 @@ pub fn as_random_ratio(value: &Yaml) -> anyhow::Result<Bernoulli> {
         )),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn as_random_ratio_ok() {
+        // valid Real values
+        let yaml = Yaml::Real("0.5".into());
+        assert_eq!(as_random_ratio(&yaml).unwrap().p(), 0.5);
+
+        let yaml = Yaml::Real("1.0".into());
+        assert_eq!(as_random_ratio(&yaml).unwrap().p(), 1.0);
+
+        // valid Integer values (0 and 1 only)
+        let yaml = Yaml::Integer(0);
+        assert_eq!(as_random_ratio(&yaml).unwrap().p(), 0.0);
+
+        let yaml = Yaml::Integer(1);
+        assert_eq!(as_random_ratio(&yaml).unwrap().p(), 1.0);
+
+        // valid String formats
+        // Fraction format
+        let yaml = yaml_str!("1/2");
+        assert_eq!(as_random_ratio(&yaml).unwrap().p(), 0.5);
+
+        // Percentage format
+        let yaml = yaml_str!("50%");
+        assert_eq!(as_random_ratio(&yaml).unwrap().p(), 0.5);
+
+        // Float string format
+        let yaml = yaml_str!("0.7");
+        assert_eq!(as_random_ratio(&yaml).unwrap().p(), 0.7);
+
+        // valid Boolean values
+        let yaml = Yaml::Boolean(true);
+        assert_eq!(as_random_ratio(&yaml).unwrap().p(), 1.0);
+
+        let yaml = Yaml::Boolean(false);
+        assert_eq!(as_random_ratio(&yaml).unwrap().p(), 0.0);
+    }
+
+    #[test]
+    fn as_random_ratio_err() {
+        // invalid Real values
+        let yaml = Yaml::Real("abc".into());
+        assert!(as_random_ratio(&yaml).is_err());
+
+        let yaml = Yaml::Real("-1.0".into());
+        assert!(as_random_ratio(&yaml).is_err());
+
+        let yaml = Yaml::Real("2.5".into());
+        assert!(as_random_ratio(&yaml).is_err());
+
+        // invalid Integer values (not 0 or 1)
+        let yaml = Yaml::Integer(2);
+        assert!(as_random_ratio(&yaml).is_err());
+
+        // invalid String formats
+        // Invalid fraction format
+        let yaml = yaml_str!("a/2");
+        assert!(as_random_ratio(&yaml).is_err());
+
+        let yaml = yaml_str!("1/b");
+        assert!(as_random_ratio(&yaml).is_err());
+
+        let yaml = yaml_str!("3/0");
+        assert!(as_random_ratio(&yaml).is_err());
+
+        // Invalid percentage format
+        let yaml = yaml_str!("a%");
+        assert!(as_random_ratio(&yaml).is_err());
+
+        let yaml = yaml_str!("150%");
+        assert!(as_random_ratio(&yaml).is_err());
+
+        // Invalid float string
+        let yaml = yaml_str!("abc");
+        assert!(as_random_ratio(&yaml).is_err());
+
+        let yaml = yaml_str!("-0.5");
+        assert!(as_random_ratio(&yaml).is_err());
+
+        // unsupported types
+        let yaml = Yaml::Array(vec![]);
+        assert!(as_random_ratio(&yaml).is_err());
+
+        let yaml = Yaml::Null;
+        assert!(as_random_ratio(&yaml).is_err());
+    }
+}

--- a/lib/g3-yaml/src/value/speed_limit.rs
+++ b/lib/g3-yaml/src/value/speed_limit.rs
@@ -172,3 +172,417 @@ pub fn as_global_datagram_speed_limit(v: &Yaml) -> anyhow::Result<GlobalDatagram
         _ => Err(anyhow!("invalid yaml value type")),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use yaml_rust::YamlLoader;
+
+    #[test]
+    fn as_tcp_sock_speed_limit_ok() {
+        // string input
+        let yaml = yaml_str!("10MB");
+        let config = as_tcp_sock_speed_limit(&yaml).unwrap();
+        assert_eq!(config.max_north, 10_000_000);
+        assert_eq!(config.max_south, 10_000_000);
+        assert_eq!(
+            config.shift_millis,
+            g3_types::net::RATE_LIMIT_SHIFT_MILLIS_DEFAULT
+        );
+
+        // integer input
+        let yaml = Yaml::Integer(102400);
+        let config = as_tcp_sock_speed_limit(&yaml).unwrap();
+        assert_eq!(config.max_north, 102400);
+        assert_eq!(config.max_south, 102400);
+        assert_eq!(
+            config.shift_millis,
+            g3_types::net::RATE_LIMIT_SHIFT_MILLIS_DEFAULT
+        );
+
+        // hash input
+        let yaml = yaml_doc!(
+            r#"
+                shift: 5
+                upload: 5MB
+                download: 10MB
+            "#
+        );
+        let config = as_tcp_sock_speed_limit(&yaml).unwrap();
+        assert_eq!(config.shift_millis, 5);
+        assert_eq!(config.max_north, 5_000_000);
+        assert_eq!(config.max_south, 10_000_000);
+
+        let yaml = yaml_doc!(
+            r#"
+                shift_millis: 10
+                upload_bytes: 1MB
+                download_bytes: 2MB
+            "#
+        );
+        let config = as_tcp_sock_speed_limit(&yaml).unwrap();
+        assert_eq!(config.shift_millis, 10);
+        assert_eq!(config.max_north, 1_000_000);
+        assert_eq!(config.max_south, 2_000_000);
+
+        let yaml = yaml_doc!(
+            r#"
+                north: 10MB
+                south: 20MB
+            "#
+        );
+        let config = as_tcp_sock_speed_limit(&yaml).unwrap();
+        assert_eq!(config.shift_millis, 0);
+        assert_eq!(config.max_north, 10_000_000);
+        assert_eq!(config.max_south, 20_000_000);
+
+        let yaml = yaml_doc!(
+            r#"
+                north_bytes: 1MB
+                south_bytes: 2MB
+            "#
+        );
+        let config = as_tcp_sock_speed_limit(&yaml).unwrap();
+        assert_eq!(config.shift_millis, 0);
+        assert_eq!(config.max_north, 1_000_000);
+        assert_eq!(config.max_south, 2_000_000);
+    }
+
+    #[test]
+    fn as_tcp_sock_speed_limit_err() {
+        // invalid type
+        let yaml = Yaml::Array(vec![]);
+        assert!(as_tcp_sock_speed_limit(&yaml).is_err());
+
+        // invalid key
+        let yaml = yaml_doc!(
+            r#"
+                invalid_key: 100
+            "#
+        );
+        assert!(as_tcp_sock_speed_limit(&yaml).is_err());
+
+        // shift value too large
+        let yaml = yaml_doc!(
+            r#"
+                shift: 100
+                upload: 1MB
+            "#
+        );
+        assert!(as_tcp_sock_speed_limit(&yaml).is_err());
+
+        // upload limit zero when shift is set
+        let yaml = yaml_doc!(
+            r#"
+                shift: 5
+                upload: 0
+            "#
+        );
+        assert!(as_tcp_sock_speed_limit(&yaml).is_err());
+
+        // invalid value
+        let yaml = yaml_doc!(
+            r#"
+                shift: abc
+            "#
+        );
+        assert!(as_tcp_sock_speed_limit(&yaml).is_err());
+
+        let yaml = yaml_doc!(
+            r#"
+                north: abc
+            "#
+        );
+        assert!(as_tcp_sock_speed_limit(&yaml).is_err());
+
+        let yaml = yaml_doc!(
+            r#"
+                south: abc
+            "#
+        );
+        assert!(as_tcp_sock_speed_limit(&yaml).is_err());
+
+        let yaml = yaml_str!("abc");
+        assert!(as_tcp_sock_speed_limit(&yaml).is_err());
+    }
+
+    #[test]
+    fn as_udp_sock_speed_limit_ok() {
+        // string input
+        let yaml = yaml_str!("5MB");
+        let config = as_udp_sock_speed_limit(&yaml).unwrap();
+        assert_eq!(config.max_north_bytes, 5_000_000);
+        assert_eq!(config.max_south_bytes, 5_000_000);
+        assert_eq!(
+            config.shift_millis,
+            g3_types::net::RATE_LIMIT_SHIFT_MILLIS_DEFAULT
+        );
+
+        // integer input
+        let yaml = Yaml::Integer(51200);
+        let config = as_udp_sock_speed_limit(&yaml).unwrap();
+        assert_eq!(config.max_north_bytes, 51200);
+        assert_eq!(config.max_south_bytes, 51200);
+        assert_eq!(
+            config.shift_millis,
+            g3_types::net::RATE_LIMIT_SHIFT_MILLIS_DEFAULT
+        );
+
+        // hash input
+        let yaml = yaml_doc!(
+            r#"
+                shift: 4
+                upload_packets: 500
+                download_packets: 1000
+                upload_bytes: 2MB
+                download_bytes: 4MB
+            "#
+        );
+        let config = as_udp_sock_speed_limit(&yaml).unwrap();
+        assert_eq!(config.shift_millis, 4);
+        assert_eq!(config.max_north_packets, 500);
+        assert_eq!(config.max_south_packets, 1000);
+        assert_eq!(config.max_north_bytes, 2_000_000);
+        assert_eq!(config.max_south_bytes, 4_000_000);
+
+        let yaml = yaml_doc!(
+            r#"
+                shift_millis: 10
+                north_packets: 1000
+                south_packets: 2000
+                north_bytes: 1MB
+                south_bytes: 2MB
+            "#
+        );
+        let config = as_udp_sock_speed_limit(&yaml).unwrap();
+        assert_eq!(config.shift_millis, 10);
+        assert_eq!(config.max_north_packets, 1000);
+        assert_eq!(config.max_south_packets, 2000);
+        assert_eq!(config.max_north_bytes, 1_000_000);
+        assert_eq!(config.max_south_bytes, 2_000_000);
+    }
+
+    #[test]
+    fn as_udp_sock_speed_limit_err() {
+        // invalid type
+        let yaml = Yaml::Null;
+        assert!(as_udp_sock_speed_limit(&yaml).is_err());
+
+        // invalid key
+        let yaml = yaml_doc!(
+            r#"
+                invalid_key: 100
+            "#
+        );
+        assert!(as_udp_sock_speed_limit(&yaml).is_err());
+
+        // shift value too large
+        let yaml = yaml_doc!(
+            r#"
+                shift: 100
+                upload_bytes: 1MB
+            "#
+        );
+        assert!(as_udp_sock_speed_limit(&yaml).is_err());
+
+        // invalid value
+        let yaml = yaml_doc!(
+            r#"
+                shift: abc
+            "#
+        );
+        assert!(as_udp_sock_speed_limit(&yaml).is_err());
+
+        let yaml = yaml_doc!(
+            r#"
+                north_bytes: def
+            "#
+        );
+        assert!(as_udp_sock_speed_limit(&yaml).is_err());
+
+        let yaml = yaml_doc!(
+            r#"
+                south_bytes: ghi
+            "#
+        );
+        assert!(as_udp_sock_speed_limit(&yaml).is_err());
+
+        let yaml = yaml_str!("abc");
+        assert!(as_udp_sock_speed_limit(&yaml).is_err());
+    }
+
+    #[test]
+    fn as_global_stream_speed_limit_ok() {
+        // string input
+        let yaml = yaml_str!("1GB");
+        let config = as_global_stream_speed_limit(&yaml).unwrap();
+        assert_eq!(config.replenish_bytes(), 1_000_000_000);
+        assert_eq!(
+            config.replenish_interval(),
+            std::time::Duration::from_secs(1)
+        );
+
+        // integer input
+        let yaml = Yaml::Integer(102400000);
+        let config = as_global_stream_speed_limit(&yaml).unwrap();
+        assert_eq!(config.replenish_bytes(), 102400000);
+        assert_eq!(
+            config.replenish_interval(),
+            std::time::Duration::from_secs(1)
+        );
+
+        // hash input
+        let yaml = yaml_doc!(
+            r#"
+                replenish_interval: 500ms
+                replenish_bytes: 1MB
+                max_burst_bytes: 2MB
+            "#
+        );
+        let config = as_global_stream_speed_limit(&yaml).unwrap();
+        assert_eq!(
+            config.replenish_interval(),
+            std::time::Duration::from_millis(500)
+        );
+        assert_eq!(config.replenish_bytes(), 1_000_000);
+        assert_eq!(config.max_burst_bytes(), 2_000_000);
+    }
+
+    #[test]
+    fn as_global_stream_speed_limit_err() {
+        // invalid type
+        let yaml = Yaml::Array(vec![]);
+        assert!(as_global_stream_speed_limit(&yaml).is_err());
+
+        // no replenish_bytes set
+        let yaml = yaml_doc!(
+            r#"
+                max_burst_bytes: 1GB
+            "#
+        );
+        assert!(as_global_stream_speed_limit(&yaml).is_err());
+
+        // invalid key
+        let yaml = yaml_doc!(
+            r#"
+                invalid_key: 100
+            "#
+        );
+        assert!(as_global_stream_speed_limit(&yaml).is_err());
+
+        // invalid value
+        let yaml = yaml_doc!(
+            r#"
+                replenish_interval: abc
+            "#
+        );
+        assert!(as_global_stream_speed_limit(&yaml).is_err());
+
+        let yaml = yaml_doc!(
+            r#"
+                replenish_bytes: def
+            "#
+        );
+        assert!(as_global_stream_speed_limit(&yaml).is_err());
+
+        let yaml = yaml_doc!(
+            r#"
+                max_burst_bytes: ghi
+            "#
+        );
+        assert!(as_global_stream_speed_limit(&yaml).is_err());
+
+        let yaml = yaml_str!("abc");
+        assert!(as_global_stream_speed_limit(&yaml).is_err());
+    }
+
+    #[test]
+    fn as_global_datagram_speed_limit_ok() {
+        // string input
+        let yaml = yaml_str!("500KB");
+        let config = as_global_datagram_speed_limit(&yaml).unwrap();
+        assert_eq!(config.replenish_bytes(), 500_000);
+        assert_eq!(config.replenish_packets(), 0);
+
+        // integer input
+        let yaml = Yaml::Integer(51200);
+        let config = as_global_datagram_speed_limit(&yaml).unwrap();
+        assert_eq!(config.replenish_bytes(), 51200);
+        assert_eq!(config.replenish_packets(), 0);
+
+        // hash input
+        let yaml = yaml_doc!(
+            r#"
+                replenish_interval: 1s
+                replenish_bytes: 500KB
+                replenish_packets: 100
+                max_burst_bytes: 1MB
+                max_burst_packets: 200
+            "#
+        );
+        let config = as_global_datagram_speed_limit(&yaml).unwrap();
+        assert_eq!(
+            config.replenish_interval(),
+            std::time::Duration::from_secs(1)
+        );
+        assert_eq!(config.replenish_bytes(), 500_000);
+        assert_eq!(config.replenish_packets(), 100);
+        assert_eq!(config.max_burst_bytes(), 1_000_000);
+        assert_eq!(config.max_burst_packets(), 200);
+    }
+
+    #[test]
+    fn as_global_datagram_speed_limit_err() {
+        // invalid type
+        let yaml = Yaml::Null;
+        assert!(as_global_datagram_speed_limit(&yaml).is_err());
+
+        // invalid key
+        let yaml = yaml_doc!(
+            r#"
+                invalid_key: 100
+            "#
+        );
+        assert!(as_global_datagram_speed_limit(&yaml).is_err());
+
+        // no replenish_bytes/packets set
+        let yaml = yaml_doc!(
+            r#"
+                replenish_interval: 1s
+            "#
+        );
+        assert!(as_global_datagram_speed_limit(&yaml).is_err());
+
+        // invalid value
+        let yaml = yaml_doc!(
+            r#"
+                replenish_bytes: abc
+            "#
+        );
+        assert!(as_global_datagram_speed_limit(&yaml).is_err());
+
+        let yaml = yaml_doc!(
+            r#"
+                replenish_packets: def
+            "#
+        );
+        assert!(as_global_datagram_speed_limit(&yaml).is_err());
+
+        let yaml = yaml_doc!(
+            r#"
+                max_burst_bytes: ghi
+            "#
+        );
+        assert!(as_global_datagram_speed_limit(&yaml).is_err());
+
+        let yaml = yaml_doc!(
+            r#"
+                max_burst_packets: jkl
+            "#
+        );
+        assert!(as_global_datagram_speed_limit(&yaml).is_err());
+
+        let yaml = yaml_str!("abc");
+        assert!(as_global_datagram_speed_limit(&yaml).is_err());
+    }
+}


### PR DESCRIPTION
- Implement comprehensive test coverage for primary value parsers (u8, u16, u32, u64, f64, bool, duration, string, ASCII)
- Add tests for weighted random algorithms and choices
- Cover rate limit and quota parsing functionality
- Test TCP socket speed limit configuration parsing
- Include boundary cases, type validations, and error handling