### PR TITLE
refactor and extend parser tests to separate success/error cases

### DIFF
--- a/lib/g3-json/src/humanize/size.rs
+++ b/lib/g3-json/src/humanize/size.rs
@@ -47,7 +47,7 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn t_usize() {
+    fn as_usize_ok() {
         let j = json!({"v": "1000"});
         assert_eq!(as_usize(&j["v"]).unwrap(), 1000);
 
@@ -62,7 +62,10 @@ mod tests {
 
         let j = json!({"v": 1024});
         assert_eq!(as_usize(&j["v"]).unwrap(), 1024);
+    }
 
+    #[test]
+    fn as_usize_err() {
         let j = json!({"v": -1024});
         assert!(as_usize(&j["v"]).is_err());
 
@@ -71,5 +74,35 @@ mod tests {
 
         let j = json!({"v": ["1"]});
         assert!(as_usize(&j["v"]).is_err());
+    }
+
+    #[test]
+    fn as_u64_ok() {
+        let j = json!({"v": "1000"});
+        assert_eq!(as_u64(&j["v"]).unwrap(), 1000);
+
+        let j = json!({"v": "1K"});
+        assert_eq!(as_u64(&j["v"]).unwrap(), 1000);
+
+        let j = json!({"v": "1KB"});
+        assert_eq!(as_u64(&j["v"]).unwrap(), 1000);
+
+        let j = json!({"v": "1KiB"});
+        assert_eq!(as_u64(&j["v"]).unwrap(), 1024);
+
+        let j = json!({"v": 1024});
+        assert_eq!(as_u64(&j["v"]).unwrap(), 1024);
+    }
+
+    #[test]
+    fn as_u64_err() {
+        let j = json!({"v": -1024});
+        assert!(as_u64(&j["v"]).is_err());
+
+        let j = json!({"v": 1.01});
+        assert!(as_u64(&j["v"]).is_err());
+
+        let j = json!({"v": ["1"]});
+        assert!(as_u64(&j["v"]).is_err());
     }
 }

--- a/lib/g3-json/src/humanize/time.rs
+++ b/lib/g3-json/src/humanize/time.rs
@@ -46,7 +46,7 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn t_duration() {
+    fn as_duration_ok() {
         let j = json!({"v": "1h2m"});
         assert_eq!(
             as_duration(&j["v"]).unwrap(),
@@ -56,6 +56,18 @@ mod tests {
         let j = json!({"v": "1000"});
         assert_eq!(as_duration(&j["v"]).unwrap(), Duration::from_secs(1000));
 
+        let j = json!({"v": 1000});
+        assert_eq!(as_duration(&j["v"]).unwrap(), Duration::from_secs(1000));
+
+        let j = json!({"v": 1.01});
+        assert_eq!(
+            as_duration(&j["v"]).unwrap(),
+            Duration::try_from_secs_f64(1.01).unwrap()
+        );
+    }
+
+    #[test]
+    fn as_duration_err() {
         let j = json!({"v": "-1000"});
         assert!(as_duration(&j["v"]).is_err());
 
@@ -68,17 +80,14 @@ mod tests {
         let j = json!({"v": "1000Ah"});
         assert!(as_duration(&j["v"]).is_err());
 
-        let j = json!({"v": 1000});
-        assert_eq!(as_duration(&j["v"]).unwrap(), Duration::from_secs(1000));
+        let j = json!({"v": "invalid"});
+        assert!(as_duration(&j["v"]).is_err());
 
         let j = json!({"v": -1000});
         assert!(as_duration(&j["v"]).is_err());
 
-        let j = json!({"v": 1.01});
-        assert_eq!(
-            as_duration(&j["v"]).unwrap(),
-            Duration::try_from_secs_f64(1.01).unwrap()
-        );
+        let j = json!({"v": f64::NAN});
+        assert!(as_duration(&j["v"]).is_err());
 
         let j = json!({"v": ["1"]});
         assert!(as_duration(&j["v"]).is_err());

--- a/lib/g3-json/src/map.rs
+++ b/lib/g3-json/src/map.rs
@@ -22,3 +22,45 @@ pub fn get_required<'a>(map: &'a Map<String, Value>, k: &str) -> anyhow::Result<
         None => Err(anyhow!("no key {k} found in this map")),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn get_required_str_ok() {
+        let mut map = Map::new();
+        map.insert("valid_key".to_string(), json!("test_value"));
+        assert_eq!(get_required_str(&map, "valid_key").unwrap(), "test_value");
+
+        map.insert("empty_key".to_string(), json!(""));
+        assert_eq!(get_required_str(&map, "empty_key").unwrap(), "");
+    }
+
+    #[test]
+    fn get_required_str_err() {
+        let mut map = Map::new();
+        assert!(get_required_str(&map, "missing_key").is_err());
+
+        map.insert("invalid_type_key".to_string(), json!(42));
+        assert!(get_required_str(&map, "invalid_type_key").is_err());
+    }
+
+    #[test]
+    fn get_required_ok() {
+        let mut map = Map::new();
+        map.insert("string_key".to_string(), json!("value"));
+        map.insert("number_key".to_string(), json!(123));
+        map.insert("object_key".to_string(), json!({"field": "data"}));
+        assert!(get_required(&map, "string_key").is_ok());
+        assert!(get_required(&map, "number_key").is_ok());
+        assert!(get_required(&map, "object_key").is_ok());
+    }
+
+    #[test]
+    fn get_required_err() {
+        let map = Map::new();
+        assert!(get_required(&map, "non_existent_key").is_err());
+    }
+}

--- a/lib/g3-json/src/value/datetime.rs
+++ b/lib/g3-json/src/value/datetime.rs
@@ -25,9 +25,53 @@ mod tests {
     use super::*;
 
     #[test]
-    fn utc_tz() {
-        let value = Value::String("2019-05-23T17:38:00Z".to_string());
-        let dt = as_rfc3339_datetime(&value).unwrap();
-        assert_eq!(dt.to_rfc3339(), "2019-05-23T17:38:00+00:00");
+    fn as_rfc3339_datetime_ok() {
+        // valid RFC3339 datetime strings
+        let valid_cases = vec![
+            "2023-01-01T00:00:00Z",
+            "2025-12-31T23:59:59.999Z",
+            "1990-06-15T12:30:45+08:00",
+            "2000-02-29T14:30:00-05:00",
+        ];
+
+        for case in valid_cases {
+            let value = Value::String(case.to_string());
+            let result = as_rfc3339_datetime(&value).unwrap();
+            let expected = DateTime::parse_from_rfc3339(case)
+                .expect("valid RFC3339 string in test case")
+                .with_timezone(&Utc);
+            assert_eq!(result, expected);
+        }
+    }
+
+    #[test]
+    fn as_rfc3339_datetime_err() {
+        // invalid RFC3339 strings
+        let invalid_strings = vec![
+            "",
+            "invalid-date",
+            "2023-13-01T00:00:00Z",
+            "2023-02-30T00:00:00Z",
+            "2023-01-01 00:00:00",
+            "2023-01-01T25:00:00Z",
+        ];
+
+        for s in invalid_strings {
+            let value = Value::String(s.to_string());
+            assert!(as_rfc3339_datetime(&value).is_err());
+        }
+
+        // non-string JSON types
+        let non_string_types = vec![
+            Value::Null,
+            Value::Bool(true),
+            Value::Number(12345.into()),
+            Value::Array(vec![]),
+            Value::Object(serde_json::Map::new()),
+        ];
+
+        for value in non_string_types {
+            assert!(as_rfc3339_datetime(&value).is_err());
+        }
     }
 }

--- a/lib/g3-json/src/value/net/base.rs
+++ b/lib/g3-json/src/value/net/base.rs
@@ -91,3 +91,200 @@ pub fn as_egress_area(v: &Value) -> anyhow::Result<EgressArea> {
         ))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    #[test]
+    fn as_ipaddr_ok() {
+        // valid IPv4
+        let ipv4 = json!("192.168.1.1");
+        assert_eq!(
+            as_ipaddr(&ipv4).unwrap(),
+            IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1))
+        );
+
+        // valid IPv6
+        let ipv6 = json!("::1");
+        assert_eq!(
+            as_ipaddr(&ipv6).unwrap(),
+            IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))
+        );
+    }
+
+    #[test]
+    fn as_ipaddr_err() {
+        // invalid IP format
+        let invalid_ip = json!("256.256.256.256");
+        assert!(as_ipaddr(&invalid_ip).is_err());
+
+        // non-string type
+        let non_string = json!(12345);
+        assert!(as_ipaddr(&non_string).is_err());
+    }
+
+    #[test]
+    #[cfg(feature = "acl-rule")]
+    fn as_ip_network_ok() {
+        // CIDR format
+        let cidr = json!("192.168.1.0/24");
+        let network = as_ip_network(&cidr).unwrap();
+        assert_eq!(network.to_string(), "192.168.1.0/24");
+
+        // valid IPv4 address
+        let single_ipv4 = json!("10.0.0.1");
+        let network = as_ip_network(&single_ipv4).unwrap();
+        assert_eq!(network.to_string(), "10.0.0.1/32");
+
+        // valid IPv6 address
+        let single_ipv6 = json!("::1");
+        let network = as_ip_network(&single_ipv6).unwrap();
+        assert_eq!(network.to_string(), "::1/128");
+    }
+
+    #[test]
+    #[cfg(feature = "acl-rule")]
+    fn as_ip_network_err() {
+        // invalid network format
+        let invalid = json!("invalid_network");
+        assert!(as_ip_network(&invalid).is_err());
+
+        // non-string type
+        let non_string = json!(true);
+        assert!(as_ip_network(&non_string).is_err());
+    }
+
+    #[test]
+    fn as_host_ok() {
+        // IP host
+        let ip_host = json!("192.168.1.1");
+        assert_eq!(
+            as_host(&ip_host).unwrap(),
+            Host::Ip(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)))
+        );
+
+        // domain host
+        let domain_host = json!("example.com");
+        assert_eq!(
+            as_host(&domain_host).unwrap(),
+            Host::Domain("example.com".into())
+        );
+
+        // IDN host
+        let idn_host = json!("例子.测试");
+        assert_eq!(
+            as_host(&idn_host).unwrap(),
+            Host::Domain("xn--fsqu00a.xn--0zwm56d".into())
+        );
+    }
+
+    #[test]
+    fn as_host_err() {
+        // invalid hostname
+        let invalid_host = json!("-invalid-\u{e000}.com");
+        assert!(as_host(&invalid_host).is_err());
+
+        // non-string type
+        let non_string = json!(vec![1, 2, 3]);
+        assert!(as_host(&non_string).is_err());
+    }
+
+    #[test]
+    fn as_domain_ok() {
+        // valid domain
+        let domain = json!("example.com");
+        assert_eq!(as_domain(&domain).unwrap(), "example.com");
+
+        // IDN conversion
+        let idn = json!("例子.测试");
+        assert_eq!(as_domain(&idn).unwrap(), "xn--fsqu00a.xn--0zwm56d");
+    }
+
+    #[test]
+    fn as_domain_err() {
+        // invalid domain
+        let invalid_domain = json!("invalid\u{e000}domain");
+        assert!(as_domain(&invalid_domain).is_err());
+
+        // non-string type
+        let non_string = json!(42);
+        assert!(as_domain(&non_string).is_err());
+    }
+
+    #[test]
+    fn as_upstream_addr_ok() {
+        // IPv4 address
+        let ipv4 = json!("127.0.0.1:8080");
+        let addr = as_upstream_addr(&ipv4).unwrap();
+        assert_eq!(
+            addr.host(),
+            &Host::Ip(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)))
+        );
+        assert_eq!(addr.port(), 8080);
+
+        // IPv6 address
+        let ipv6 = json!("[2001:db8::1]:8080");
+        let addr = as_upstream_addr(&ipv6).unwrap();
+        assert_eq!(
+            addr.host(),
+            &Host::Ip(IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)))
+        );
+        assert_eq!(addr.port(), 8080);
+
+        // domain address
+        let domain = json!("example.com:443");
+        let addr = as_upstream_addr(&domain).unwrap();
+        assert_eq!(addr.host(), &Host::Domain("example.com".into()));
+        assert_eq!(addr.port(), 443);
+    }
+
+    #[test]
+    fn as_upstream_addr_err() {
+        // invalid format
+        let invalid_format = json!("invalid\u{e000}address");
+        assert!(as_upstream_addr(&invalid_format).is_err());
+
+        // invalid port number
+        let invalid_port = json!("example.com:99999");
+        assert!(as_upstream_addr(&invalid_port).is_err());
+    }
+
+    #[test]
+    fn as_egress_area_ok() {
+        // single-level area
+        let single = json!("area1");
+        assert_eq!(as_egress_area(&single).unwrap().to_string(), "area1");
+
+        // multi-level area
+        let multi = json!("area1/area2/area3");
+        assert_eq!(
+            as_egress_area(&multi).unwrap().to_string(),
+            "area1/area2/area3"
+        );
+
+        // with spaces
+        let with_spaces = json!("  area1 / area2  ");
+        assert_eq!(
+            as_egress_area(&with_spaces).unwrap().to_string(),
+            "area1 / area2"
+        );
+    }
+
+    #[test]
+    fn as_egress_area_err() {
+        // empty area
+        let empty = json!("");
+        assert!(as_egress_area(&empty).is_err());
+
+        // slashes only
+        let slashes = json!("///");
+        assert!(as_egress_area(&slashes).is_err());
+
+        // non-string type
+        let non_string = json!(123);
+        assert!(as_egress_area(&non_string).is_err());
+    }
+}

--- a/lib/g3-json/src/value/net/ports.rs
+++ b/lib/g3-json/src/value/net/ports.rs
@@ -42,3 +42,96 @@ pub fn as_ports(value: &Value) -> anyhow::Result<Ports> {
         _ => Err(anyhow!("invalid value type")),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn as_ports_ok() {
+        // valid number input (single port)
+        let value = json!(8080);
+        let ports = as_ports(&value).unwrap();
+        assert!(ports.contains(8080));
+
+        // valid string input (single port)
+        let value = json!("80");
+        let ports = as_ports(&value).unwrap();
+        assert!(ports.contains(80));
+
+        // valid string input (port range)
+        let value = json!("1000-1002");
+        let ports = as_ports(&value).unwrap();
+        assert!(ports.contains(1000));
+        assert!(ports.contains(1001));
+        assert!(ports.contains(1002));
+
+        // valid string input (mixed expression)
+        let value = json!("80,443,3000-3002");
+        let ports = as_ports(&value).unwrap();
+        assert!(ports.contains(80));
+        assert!(ports.contains(443));
+        assert!(ports.contains(3000));
+        assert!(ports.contains(3001));
+        assert!(ports.contains(3002));
+
+        // valid array input (pure numbers)
+        let value = json!([8080, 8081]);
+        let ports = as_ports(&value).unwrap();
+        assert!(ports.contains(8080));
+        assert!(ports.contains(8081));
+
+        // valid array input (pure strings)
+        let value = json!(["80-82", "443"]);
+        let ports = as_ports(&value).unwrap();
+        assert!(ports.contains(80));
+        assert!(ports.contains(81));
+        assert!(ports.contains(82));
+        assert!(ports.contains(443));
+
+        // valid array input (mixed types)
+        let value = json!([8080, "443", "3000-3002"]);
+        let ports = as_ports(&value).unwrap();
+        assert!(ports.contains(8080));
+        assert!(ports.contains(443));
+        assert!(ports.contains(3000));
+        assert!(ports.contains(3001));
+        assert!(ports.contains(3002));
+
+        // boundary values
+        let value = json!([0, 65535]);
+        let ports = as_ports(&value).unwrap();
+        assert!(ports.contains(0));
+        assert!(ports.contains(65535));
+    }
+
+    #[test]
+    fn as_ports_err() {
+        // invalid type
+        let value = json!(true);
+        assert!(as_ports(&value).is_err());
+
+        let value = json!({ "key": "value" });
+        assert!(as_ports(&value).is_err());
+
+        // invalid number (out of u16 range)
+        let value = json!(70000);
+        assert!(as_ports(&value).is_err());
+
+        // invalid string format
+        let value = json!("1000-2000-3000");
+        assert!(as_ports(&value).is_err());
+
+        let value = json!("abc");
+        assert!(as_ports(&value).is_err());
+
+        // invalid range (start > end)
+        let value = json!("2000-1000");
+        assert!(as_ports(&value).is_err());
+
+        // array with invalid element
+        let value = json!([8080, true, "443"]);
+        assert!(as_ports(&value).is_err());
+    }
+}

--- a/lib/g3-json/src/value/net/proxy.rs
+++ b/lib/g3-json/src/value/net/proxy.rs
@@ -21,3 +21,59 @@ pub fn as_proxy_request_type(v: &Value) -> anyhow::Result<ProxyRequestType> {
         ))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn as_proxy_request_type_ok() {
+        // all valid enum values and their supported string formats
+        let test_cases = vec![
+            ("httpforward", ProxyRequestType::HttpForward),
+            ("HTTPForward", ProxyRequestType::HttpForward),
+            ("http_forward", ProxyRequestType::HttpForward),
+            ("httpsforward", ProxyRequestType::HttpsForward),
+            ("HTTPSForward", ProxyRequestType::HttpsForward),
+            ("https_forward", ProxyRequestType::HttpsForward),
+            ("ftpoverhttp", ProxyRequestType::FtpOverHttp),
+            ("FTPOverHttp", ProxyRequestType::FtpOverHttp),
+            ("ftp_over_http", ProxyRequestType::FtpOverHttp),
+            ("httpconnect", ProxyRequestType::HttpConnect),
+            ("HTTPConnect", ProxyRequestType::HttpConnect),
+            ("http_connect", ProxyRequestType::HttpConnect),
+            ("sockstcpconnect", ProxyRequestType::SocksTcpConnect),
+            ("SocksTCPConnect", ProxyRequestType::SocksTcpConnect),
+            ("socks_tcp_connect", ProxyRequestType::SocksTcpConnect),
+            ("socksudpassociate", ProxyRequestType::SocksUdpAssociate),
+            ("SocksUDPAssociate", ProxyRequestType::SocksUdpAssociate),
+            ("socks_udp_associate", ProxyRequestType::SocksUdpAssociate),
+        ];
+
+        for (input, expected) in test_cases {
+            let value = Value::String(input.to_string());
+            let result = as_proxy_request_type(&value).unwrap();
+            assert_eq!(result, expected);
+        }
+    }
+
+    #[test]
+    fn as_proxy_request_type_err() {
+        // invalid string
+        let invalid_str = Value::String("invalid_type".to_string());
+        assert!(as_proxy_request_type(&invalid_str).is_err());
+
+        // non-string types
+        let non_string_types = vec![
+            Value::Bool(true),
+            Value::Number(42.into()),
+            Value::Null,
+            Value::Array(vec![]),
+            Value::Object(serde_json::Map::new()),
+        ];
+
+        for value in non_string_types {
+            assert!(as_proxy_request_type(&value).is_err());
+        }
+    }
+}

--- a/lib/g3-json/src/value/net/tcp.rs
+++ b/lib/g3-json/src/value/net/tcp.rs
@@ -145,3 +145,145 @@ pub fn as_tcp_misc_sock_opts(v: &Value) -> anyhow::Result<TcpMiscSockOpts> {
         ))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::time::Duration;
+
+    #[test]
+    fn as_tcp_connect_config_ok() {
+        // valid configuration
+        let valid = json!({
+            "max_retry": 5,
+            "each_timeout": "30s"
+        });
+        let config = as_tcp_connect_config(&valid).unwrap();
+        assert_eq!(config.max_tries(), 6);
+        assert_eq!(config.each_timeout(), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn as_tcp_connect_config_err() {
+        // invalid key
+        let invalid_key = json!({"invalid_key": 10});
+        assert!(as_tcp_connect_config(&invalid_key).is_err());
+
+        // invalid value type
+        let invalid_value = json!({"max_retry": "string"});
+        assert!(as_tcp_connect_config(&invalid_value).is_err());
+
+        // non-object input
+        let non_object = json!(["array"]);
+        assert!(as_tcp_connect_config(&non_object).is_err());
+    }
+
+    #[test]
+    fn as_tcp_keepalive_config_ok() {
+        // object form with all keys
+        let obj = json!({
+            "enable": true,
+            "idle_time": "60s",
+            "probe_interval": "5s",
+            "probe_count": 3
+        });
+        let config = as_tcp_keepalive_config(&obj).unwrap();
+        assert!(config.is_enabled());
+        assert_eq!(config.idle_time(), Duration::from_secs(60));
+        assert_eq!(config.probe_interval(), Some(Duration::from_secs(5)));
+        assert_eq!(config.probe_count(), Some(3));
+
+        // boolean form
+        let bool_true = json!(true);
+        let config = as_tcp_keepalive_config(&bool_true).unwrap();
+        assert!(config.is_enabled());
+
+        let bool_false = json!(false);
+        let config = as_tcp_keepalive_config(&bool_false).unwrap();
+        assert!(!config.is_enabled());
+
+        // duration string form
+        let duration_str = json!("30s");
+        let config = as_tcp_keepalive_config(&duration_str).unwrap();
+        assert!(config.is_enabled());
+        assert_eq!(config.idle_time(), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn as_tcp_keepalive_config_err() {
+        // invalid key
+        let invalid_key = json!({"invalid_key": true});
+        assert!(as_tcp_keepalive_config(&invalid_key).is_err());
+
+        // invalid value type
+        let invalid_value = json!({"idle_time": true});
+        assert!(as_tcp_keepalive_config(&invalid_value).is_err());
+
+        // invalid duration format
+        let invalid_duration = json!("invalid");
+        assert!(as_tcp_keepalive_config(&invalid_duration).is_err());
+    }
+
+    #[test]
+    fn as_tcp_misc_sock_opts_ok() {
+        // common keys supported on all platforms
+        let common_json = json!({
+            "no_delay": true,
+            "max_segment_size": 1460,
+            "ttl": 64,
+            "hop_limit": 64,
+            "tos": 32,
+        });
+
+        let config = as_tcp_misc_sock_opts(&common_json).unwrap();
+        assert_eq!(config.no_delay, Some(true));
+        assert_eq!(config.max_segment_size, Some(1460));
+        assert_eq!(config.time_to_live, Some(64));
+        assert_eq!(config.hop_limit, Some(64));
+        assert_eq!(config.type_of_service, Some(32));
+
+        // traffic_class on non-Windows platforms
+        #[cfg(not(windows))]
+        {
+            let traffic_json = json!({"traffic_class": 16});
+            let config = as_tcp_misc_sock_opts(&traffic_json).unwrap();
+            assert_eq!(config.traffic_class, Some(16));
+        }
+
+        // platform-specific keys
+        #[cfg(any(
+            target_os = "linux",
+            target_os = "freebsd",
+            target_os = "solaris",
+            target_os = "illumos"
+        ))]
+        {
+            let congestion_json = json!({"congestion_control": "cubic"});
+            let config = as_tcp_misc_sock_opts(&congestion_json).unwrap();
+            assert_eq!(config.congestion_control().unwrap(), b"cubic");
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            let mark_json = json!({"mark": 12345});
+            let config = as_tcp_misc_sock_opts(&mark_json).unwrap();
+            assert_eq!(config.netfilter_mark, Some(12345));
+        }
+    }
+
+    #[test]
+    fn as_tcp_misc_sock_opts_err() {
+        // invalid key
+        let invalid_key = json!({"invalid_key": true});
+        assert!(as_tcp_misc_sock_opts(&invalid_key).is_err());
+
+        // invalid value type
+        let invalid_value = json!({"no_delay": "string"});
+        assert!(as_tcp_misc_sock_opts(&invalid_value).is_err());
+
+        // non-object input
+        let non_object = json!(123);
+        assert!(as_tcp_misc_sock_opts(&non_object).is_err());
+    }
+}

--- a/lib/g3-json/src/value/net/tls.rs
+++ b/lib/g3-json/src/value/net/tls.rs
@@ -24,3 +24,80 @@ pub fn as_tls_version(value: &Value) -> anyhow::Result<TlsVersion> {
         )),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn as_tls_version_ok() {
+        // all valid string representations for each TLS version
+        let valid_versions = [
+            (
+                TlsVersion::TLS1_0,
+                vec!["1.0", "tls10", "tls1.0", "tls1_0", "TLS10", "TLS1.0"],
+            ),
+            (
+                TlsVersion::TLS1_1,
+                vec!["1.1", "tls11", "tls1.1", "tls1_1", "TLS11", "TLS1.1"],
+            ),
+            (
+                TlsVersion::TLS1_2,
+                vec!["1.2", "tls12", "tls1.2", "tls1_2", "TLS12", "TLS1.2"],
+            ),
+            (
+                TlsVersion::TLS1_3,
+                vec!["1.3", "tls13", "tls1.3", "tls1_3", "TLS13", "TLS1.3"],
+            ),
+        ];
+
+        for (expected_version, strings) in valid_versions {
+            for s in strings {
+                let value = json!(s);
+                let version = as_tls_version(&value).unwrap();
+                assert_eq!(version, expected_version);
+            }
+        }
+
+        // all valid float representations
+        let valid_floats = [1.0, 1.1, 1.2, 1.3];
+        for f in valid_floats {
+            let value = json!(f);
+            let version = as_tls_version(&value).unwrap();
+            assert_eq!(version, TlsVersion::try_from(f).unwrap());
+        }
+
+        // valid integer representation (converted to float)
+        let value = json!(1);
+        let version = as_tls_version(&value).unwrap();
+        assert_eq!(version, TlsVersion::TLS1_0);
+    }
+
+    #[test]
+    fn as_tls_version_err() {
+        // invalid string representations
+        let invalid_strings = ["0.9", "ssl3.0", "", "tls1", "tls2.0"];
+        for s in invalid_strings {
+            let value = json!(s);
+            assert!(as_tls_version(&value).is_err());
+        }
+
+        // invalid float values
+        let invalid_floats = [0.9, 1.5, 2.0, -1.0];
+        for f in invalid_floats {
+            let value = json!(f);
+            assert!(as_tls_version(&value).is_err());
+        }
+
+        // invalid integer value (converted to float 2.0)
+        let value = json!(2);
+        assert!(as_tls_version(&value).is_err());
+
+        // invalid types
+        assert!(as_tls_version(&json!(true)).is_err());
+        assert!(as_tls_version(&json!([])).is_err());
+        assert!(as_tls_version(&json!({})).is_err());
+        assert!(as_tls_version(&json!(null)).is_err());
+    }
+}

--- a/lib/g3-json/src/value/net/udp.rs
+++ b/lib/g3-json/src/value/net/udp.rs
@@ -52,3 +52,55 @@ pub fn as_udp_misc_sock_opts(v: &Value) -> anyhow::Result<UdpMiscSockOpts> {
         ))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn as_udp_misc_sock_opts_ok() {
+        // all valid keys including aliases
+        let valid_json = json!({
+            "time_to_live": 64,
+            "hop_limit": 32,
+            "type_of_service": 8,
+        });
+
+        let config = as_udp_misc_sock_opts(&valid_json).unwrap();
+        assert_eq!(config.time_to_live, Some(64));
+        assert_eq!(config.hop_limit, Some(32));
+        assert_eq!(config.type_of_service, Some(8));
+
+        // platform-specific tests
+        #[cfg(not(windows))]
+        {
+            let traffic_json = json!({"traffic_class": 3});
+            let config = as_udp_misc_sock_opts(&traffic_json).unwrap();
+            assert_eq!(config.traffic_class, Some(3));
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            let mark_json = json!({"netfilter_mark": 99});
+            let config = as_udp_misc_sock_opts(&mark_json).unwrap();
+            assert_eq!(config.netfilter_mark, Some(99));
+        }
+    }
+
+    #[test]
+    fn as_udp_misc_sock_opts_err() {
+        // non-object input
+        let array_input = json!([1, 2, 3]);
+        assert!(as_udp_misc_sock_opts(&array_input).is_err());
+
+        // invalid key
+        let invalid_key = json!({"invalid_key": 100});
+        assert!(as_udp_misc_sock_opts(&invalid_key).is_err());
+
+        // type error
+        let type_error = json!({"ttl": "not_a_number"});
+        assert!(type_error.get("ttl").unwrap().is_string());
+        assert!(as_udp_misc_sock_opts(&type_error).is_err());
+    }
+}


### PR DESCRIPTION
- Split existing tests into distinct `_ok` and `_err` cases for clearer test organization
- Add comprehensive new test cases for:
  - Numeric parsers (size, datetime, ports)
  - Network address parsers (IPv4/IPv6, HTTP headers)
  - Duration and ACL set parsers
  - Map and proxy request type validation
- Cover edge cases, boundary values, and invalid inputs